### PR TITLE
minor updates to template

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,6 +1,7 @@
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - Target Major Version: (2.x / 3.x / X.x)
 - Reference Issues: (fill in existing related issues, if any)
+- Status: Pending (change to Active if the RFC is accepted and merged)
 - Implementation PR: (leave this empty)
 
 # Summary
@@ -39,10 +40,6 @@ There are tradeoffs to choosing any path. Attempt to identify them here.
 # Alternatives
 
 What other designs have been considered? What is the impact of not doing this?
-
-# Adoption strategy
-
-If we implement this proposal, how will existing Cedar users adopt it? Is this a breaking change? Can we write a codemod? Can we provide a runtime adapter library for the original API it replaces? How will this affect other projects in the Cedar  ecosystem?
 
 # Unresolved questions
 

--- a/0000-template.md
+++ b/0000-template.md
@@ -1,19 +1,27 @@
-- Start Date: (fill me in with today's date, YYYY-MM-DD)
-- Target Major Version: (2.x / 3.x / X.x)
-- Reference Issues: (fill in existing related issues, if any)
-- Status: Pending (change to Active if the RFC is accepted and merged)
-- Implementation PR: (leave this empty)
+# RFC Template (Fill in your title here)
 
-# Summary
+## Related issues and PRs
+
+- Reference Issues: (fill in existing related issues, if any)
+- Implementation PR(s): (leave this empty)
+
+## Timeline
+
+- Start Date: (fill in with today's date, YYYY-MM-DD)
+- Date Entered FCP: (leave this empty, update when the PR enters FCP)
+- Date Accepted: (leave this empty, update when the PR is merged)
+- Date Landed: (leave this empty, update when the implementation is in a stable release)
+
+## Summary
 
 Brief explanation of the feature.
 
-# Basic example
+## Basic example
 
 If the proposal involves a new or changed API, include a basic code example.
 Omit this section if it's not applicable.
 
-# Motivation
+## Motivation
 
 Why are we doing this? What use cases does it support? What is the expected
 outcome?
@@ -23,11 +31,11 @@ the motivation could be used to develop alternative solutions. In other words,
 enumerate the constraints you are trying to solve without coupling them too
 closely to the solution you have in mind.
 
-# Detailed design
+## Detailed design
 
 This is the bulk of the RFC. Explain the design in enough detail for somebody familiar with Cedar to understand, and for somebody familiar with the implementation to implement. This should get into specifics and corner-cases, and include examples of how the feature is used. Any new terminology should be defined here.
 
-# Drawbacks
+## Drawbacks
 
 Why should we *not* do this? Please consider:
 
@@ -37,11 +45,11 @@ Why should we *not* do this? Please consider:
 
 There are tradeoffs to choosing any path. Attempt to identify them here.
 
-# Alternatives
+## Alternatives
 
 What other designs have been considered? What is the impact of not doing this?
 
-# Unresolved questions
+## Unresolved questions
 
 Optional, but suggested for first drafts. What parts of the design are still
 TBD?


### PR DESCRIPTION
A couple quick updates to the RFC template:
* Add a "Status" so that people can easily check if an RFC is Active/Landed/Rejected (using the terminology in the README).
* Remove the "Adoption strategy" section because this information is already covered by other sections (e.g., "Drawbacks").


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
