### PR TITLE
Update description of validation for `is` operator

### DIFF
--- a/text/0005-is-operator.md
+++ b/text/0005-is-operator.md
@@ -94,8 +94,9 @@ Namespaces are considered "part of" the entity type. So:
 
 ### Changes required to validator
 
-`e is et` will be typed as `True` if the validator can guarantee that expression `e` is an entity of type `et`, or `False` if the validator can guarantee that `e` is a non-entity type or an entity not of type `et`.
-Otherwise, the validator gives `e is et` type `Bool`.
+`e is et` will be typed as `True` if the validator can guarantee that expression `e` is an entity of type `et`, or `False` if the validator can guarantee that `e` is an entity not of type `et`.
+If the validator can guarantee that `e` is an entity, but not determine the exact type, then `e is et` is given type `Bool`.
+Otherwise, the validator produces a type error.
 
 To improve typing precision, we can extend the current notion of "effects" to track information about entity types.
 Currently, the validator uses effects to know whether an expression is guaranteed to have an attribute.


### PR DESCRIPTION
<!--
The below link will link to the rendered Markdown for your RFC, even before it is merged. You need to adjust it based on your RFC's filename and which fork and branch your PR is from.

* USERNAME: GitHub account or org where your fork of `rfcs` lives. Internal users using a feature branch of `cedar-policy` can just put `cedar-policy` here.

* REPONAME: Probably `rfcs` unless your fork has a different name

* BRANCHNAME: Name of the branch your PR is based on

* FILENAME.md: Filename of your RFC's markdown

Examples:

https://github.com/cedar-policy/rfcs/blob/placeholders-in-conditions/text/0003-placeholders-in-conditions.md

https://github.com/myusername/rfcs/blob/awesome-rfc-idea/text/0001-awesome-rfc-idea.md

-->

The current text on validation for the `is` operator is unsound -- it was written when the plan was for `is` to be total (i.e., return `true` or `false` for every expression rather than error). See [this thread](https://github.com/cedar-policy/rfcs/pull/5#discussion_r1253264478) for discussion.

This PR fixes the description of the typing rule. Because this is a minor fix to an existing PR, we do not expect to do a full FCP before accepting (unless reviewers point out significant problems).

<!-- FIXME -->
[Rendered](https://github.com/cedar-policy/rfcs/blob/update-rfc-5/text/0005-is-operator.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
