### PR TITLE
Support version annotations on Cedar inputs

### DIFF
--- a/text/0033-input-versions.md
+++ b/text/0033-input-versions.md
@@ -167,6 +167,8 @@ Adding an annotation adds some maintenance burden on customers. When a version a
 
 If an input format changes in a way that older syntax is interpreted differently, such as the `appliesTo` in the JSON schema as per the request in [issue 351](https://github.com/cedar-policy/cedar/issues/351), the fact that a version annotation is optional presents a problem: A newer and older parser could both accept the same input, but interpret it differently. If a version annotation was required, such an ambiguous interpretation would not be possible.
 
+Providing language-version annotations in code files is unusual. Go permits [specifying the language minimum version in a module's metadata file](https://go.dev/ref/mod#go-mod-file-go), but not in the code itself.
+
 ## Alternatives
 
 ### Do nothing to Cedar; version info can appear in application metadata
@@ -183,9 +185,11 @@ Rather than add a version annotation in the Cedar input syntax directly, version
     }
 }
 ```
-Such annotations could then trigger different application actions, e.g., calling different versions of the Cedar evaluator.
+Such annotations could then trigger different application actions, e.g., calling different versions of the Cedar evaluator. As a real-world example, the [`go` directive](https://go.dev/ref/mod#go-mod-file-go) in Go-language module metadata is used to select which toolchain to run.
 
 Versioning is especially useful when the same syntax is interpreted differently in later versions. This situation should be (very) rare, though. When it happens, the newer parser can warn about the change in syntax, especially in the case of errors that would trigger due to the change.
+
+Some comments on earlier versions of this RFC suggested that versioning might be most naturally given within a single configuration file that applies to a group of schemas, entity data, policies, etc. rather than associated with individual files.
 
 ### Change, or drop, the policy annotation format
 

--- a/text/0033-input-versions.md
+++ b/text/0033-input-versions.md
@@ -17,7 +17,7 @@ Reserve a way to indicate the Cedar version of an input format, so that future v
 
 Cedar policies:
 ```
-__cedar::version("3.0");
+@cedar_version("3.0");
 permit(principal,action,resource) when {
     principal is User && resource.owner == principal
 };
@@ -25,7 +25,7 @@ permit(principal,action,resource) when {
 JSON Cedar entities:
 ```
 {
-    "__cedar::version": "2.4",
+    "@cedar_version": "2.4",
     "contents": [
         {
             "uid": { "__entity": { "type": "User", "id": "alice"} },
@@ -38,7 +38,7 @@ JSON Cedar entities:
 JSON Cedar schema:
 ```
 {
-    "__cedar::version": "2.4",
+    "@cedar_version": "2.4",
     "PhotoApp": {
         "entityTypes": {
             "User": {
@@ -53,7 +53,7 @@ JSON Cedar schema:
 ```
 [Custom Cedar schema](0024-schema-syntax.md):
 ```
-@__cedar::version("3.0");
+@cedar_version("3.0");
 entity UserGroup;
 entity User in [UserGroup];
 entity List {
@@ -65,9 +65,9 @@ entity List {
 
 Cedar will occasionally make breaking changes which invalidate prior Cedar input formats. For example [RFC 20](0020-unique-record-keys.md) requires that keys in records be unique, both in policies and in entities, whereas pre-RFC 20 they did not have to be. 
 
-This RFC proposes to define annotations that signal the associated version of a particular input format, so that future versions of Cedar (or tools/services that use Cedar) can handle the situation gracefully. 
+This RFC proposes to define annotations that signal the associated version of a particular input format, so that future versions of Cedar (or tools/services that use Cedar) can handle the situation gracefully.
 
-For example, by annotating a policy or JSON input file with version 2.4, the parser for Cedar version 3.0 can flag an input with a 2.4-only feature as no longer supported, rather than just failing to parse. Or, a service that uses Cedar can run multiple versions of the Cedar tools, selecting the version that matches the input version they are given.
+This RFC makes no specification about what "gracefully" means, but minimally it can be used to indicate that parse errors might be due to version format incompatibilities. For example, by annotating a policy or JSON input file with version 2.4, the parser for Cedar version 3.0 can flag an input with a 2.4-only feature as no longer supported, rather than just failing to parse. Or, a service that uses Cedar can run multiple versions of the Cedar tools, selecting the version that matches the input version they are given.
 
 ## Detailed design
 
@@ -89,7 +89,7 @@ If an input file is annotated with an ill-formed version string, the parser shou
 
 For Cedar policies and custom schema syntax, we propose adding a new top-level declaration:
 ```
-__cedar::version(XXX);
+@cedar_version(XXX);
 ```
 where `XXX` is a string with the version in it.
 
@@ -98,25 +98,25 @@ This declaration applies to all policies or schema elements that are parsed in t
 Here is the amended grammar for a policies file:
 ```
 File    := {Policy | Version}
-Version := '__cedar::version' '(' STRING ')' ';'
+Version := '@cedar_version' '(' STRING ')' ';'
 Policy  := {Annotation} Effect '(' Scope ')' {Conditions} ';'
 ...
 ```
 Here is the amended grammar for a custom schema:
 ```
 Schema    := {Namespace | Version}
-Version   := '__cedar::version' '(' STRING ')' ';'
+Version   := '@cedar_version' '(' STRING ')' ';'
 Namespace := ('namespace' Path '{' {Decl} '}') | {Decl}
 ...
 ```
-In both cases there is the semantic constraint that `VERSION` appears at most once.
+In both cases there is the semantic constraint that `Version` appears at most once.
 
 ### Entities JSON
 
 The Cedar entities JSON is now defined as an array of entity records. We propose to update it to be a record containing a version declaration followed by that array. In particular:
 ```
 {
-    "__cedar::version": XXX,
+    "@cedar_version": XXX,
     "contents": [
         ...
     ]
@@ -139,10 +139,10 @@ The Cedar schema JSON is now defined as a record whose elements are individual n
     }
 }
 ```
-We propose to extend this format so that one of the "namespace" elements can be `"__cedar::version"`, and it will be associated with the version string XXX, i.e.,
+We propose to extend this format so that one of the "namespace" elements can be `"@cedar_version"`, and it will be associated with the version string XXX, i.e.,
 ```
 {
-    "__cedar::version": XXX, 
+    "@cedar_version": XXX,
     "Name::space::one": {
         ...
     },
@@ -151,16 +151,59 @@ We propose to extend this format so that one of the "namespace" elements can be 
     }
 }
 ```
-This approach is unambiguous, and optional, because the namespace element `__cedar` is reserved, so no legal schema could define its own namespace containing `__cedar`. (This change was made as part of the [RFC 24](0024-schema-syntax.md).)
+This approach is unambiguous, and optional, because the element `@cedar_version` cannot be misinterpreted as a namespace, since `@` is not allowed to appear in a namespace identifier.
+
+### Compatibility
+
+The old, version-free format will still be accepted assuming inputs do not rely on changes to format such as [RFC 20](0020-unique-record-keys.md).
 
 ## Drawbacks
 
-Implementing this RFC will add some complexity to the various Cedar parsers. They will now have to accept inputs that have a version annotation, and those that do not. They should also use that annotation to improve functionality and/or error messages, but such improvements do not have to come right away.
+Implementing this RFC will add some complexity to the various Cedar parsers. They will now have to accept inputs that have a version annotation, and those that do not. They will have to minimally use that annotation to improve functionality and/or error messages. Doing this requires thinking carefully about the meaning of an annotation (e.g., what span of versions use the same format).
 
-On the other hand, this RFC is essentially backward compatible -- the old, version-free format will still be accepted (assuming inputs do not rely on changes to format such as [RFC 20](0020-unique-record-keys.md)).
+The presence of a version annotation may imply more than this RFC is actually offering, leading to customer confusion or disappointment. For example, customers may expect that the current parser can parse and properly interpret all formats up to the present one, rather than reject those earlier formats (gracefully).
+
+Adding an annotation adds some maintenance burden on customers. When a version annotation is present in a policy file, if the policies are changed to use a newer version of Cedar, the version annotation needs to be changed; it is not hard to forget to do so.
+
+If an input format changes in a way that older syntax is interpreted differently, such as the `appliesTo` in the JSON schema as per the request in [issue 351](https://github.com/cedar-policy/cedar/issues/351), the fact that a version annotation is optional presents a problem: A newer and older parser could both accept the same input, but interpret it differently. If a version annotation was required, such an ambiguous interpretation would not be possible.
 
 ## Alternatives
 
-We could consider versioning individual input elements, rather than whole input files. For example, we could have proposed to use metadata annotations like `@version("2.4.1")` as annotations on individual policies. However, this seems like overkill -- most likely all policies in one batch have the same version; if they do not, you can separate them into multiple batches.
+### Do nothing to Cedar; version info can appear in application metadata
 
-The use of `__cedar::version` as the keyword to identify a version may look a little strange; we might prefer to just write `version` or `cedar_version`. The use of the version key with `__cedar` is crucial for supporting versioning in JSON-based schemas, and for uniformity we thought it best to use the same key everywhere. Also, the presence of `__cedar` in the keyword makes clear that it indicates the _Cedar language_ version, not a version associated with the application using Cedar.
+Rather than add a version annotation in the Cedar input syntax directly, version information can just be stored in metadata. For example, an application could store Cedar schemas in a document database and use a format like
+```
+{
+    "cedar_verson": "3.1.0",
+    "schema" : {
+        "foo::bar" {
+            "entityTypes" : { ... },
+            "actions": { ... }
+        }
+    }
+}
+```
+Such annotations could then trigger different application actions, e.g., calling different versions of the Cedar evaluator.
+
+Versioning is especially useful when the same syntax is interpreted differently in later versions. This situation should be (very) rare, though. When it happens, the newer parser can warn about the change in syntax, especially in the case of errors that would trigger due to the change.
+
+### Change, or drop, the policy annotation format
+
+The use of `;` to distinguish per-policy annotations from file-wide policy annotations may be too subtle. Users could mistakenly write the following:
+```
+@cedar_version("2.4.0")
+permit(
+    principal == User::"Alice",
+    action == Action::"viewPhoto",
+    resource == Photo::"vacation97.jpg"
+);
+```
+They might think that the version applies to the whole file, but the lack of a semi-colon means the annotation just applies to the given policy.
+
+To avoid this problem, we could require a distinct syntax for file-wide annotations, e.g., `#foo("...")` rather than `@foo("...");` For `cedar_version` in particular, we could make a warning whenever this id is used as an annotation on an individual policy, rather than the whole file.
+
+We could also avoid versioning policies (and custom schemas) entirely, with the intention that policy syntax will always be backward compatible. We could limit version annotations on JSON-based formats instead.
+
+#### Make new-version parsers accept old formats
+
+Rather than reject inputs for older formats, newer parsers could accept those formats. For example, a new schema parser could interpret JSON schemas per [issue 351](https://github.com/cedar-policy/cedar/issues/351) by default, but if the schema is labeled as version "2.4" or earlier then the older intepretation could be used. This is both customer friendly and avoids errors. The cost is a significant maintenance burden for development, which creates a greater chance of errors.

--- a/text/0033-input-versions.md
+++ b/text/0033-input-versions.md
@@ -1,0 +1,166 @@
+# Input Version Annotation
+
+## Related issues and PRs
+
+- Reference Issues:
+- Implementation PR(s):
+
+## Timeline
+
+- Started: 2013-10-13
+
+## Summary
+
+Reserve a way to indicate the Cedar version of an input format, so that future versions of Cedar can recognize and gracefully handle earlier input formats.
+
+## Basic example
+
+Cedar policies:
+```
+__cedar::version("3.0");
+permit(principal,action,resource) when {
+    principal is User && resource.owner == principal
+};
+```
+JSON Cedar entities:
+```
+{
+    "__cedar::version": "2.4",
+    "contents": [
+        {
+            "uid": { "__entity": { "type": "User", "id": "alice"} },
+            "attrs": {},
+            "parents": [{ "__entity": { "type": "UserGroup", "id": "jane_friends"} }]
+        }, ... 
+    ]
+}
+```
+JSON Cedar schema:
+```
+{
+    "__cedar::version": "2.4",
+    "PhotoApp": {
+        "entityTypes": {
+            "User": {
+                "memberOfTypes": [
+                    "UserGroup"
+                ]
+            }, ...
+        },
+        "actions": ...
+    }
+}
+```
+[Custom Cedar schema](0024-schema-syntax.md):
+```
+@__cedar::version("3.0");
+entity UserGroup;
+entity User in [UserGroup];
+entity List {
+    owner: User
+};
+```
+
+## Motivation
+
+Cedar will occasionally make breaking changes which invalidate prior Cedar input formats. For example [RFC 20](0020-unique-record-keys.md) requires that keys in records be unique, both in policies and in entities, whereas pre-RFC 20 they did not have to be. 
+
+This RFC proposes to define annotations that signal the associated version of a particular input format, so that future versions of Cedar (or tools/services that use Cedar) can handle the situation gracefully. 
+
+For example, by annotating a policy or JSON input file with version 2.4, the parser for Cedar version 3.0 can flag an input with a 2.4-only feature as no longer supported, rather than just failing to parse. Or, a service that uses Cedar can run multiple versions of the Cedar tools, selecting the version that matches the input version they are given.
+
+## Detailed design
+
+This RFC proposes a version annotation on Cedar's main input types: policies, entities (JSON), schema (JSON and custom). 
+
+The design has two main goals:
+
+- **Optional**: No version annotation is required. If none is given, the Cedar parser will assume the most recent version.
+
+- **Uniform**: The way of specifying the version should be similar across all input formats, but also adhere to their particular style.
+
+### Version string
+
+Each input file will be associated with a version string. This is the version the input was written for, e.g., `"2.4.1"` or `"3.0"`. It could be that newer Cedar versions are compatible with older formats, but it is up to newer parsers to know that. For example, a new version of Cedar will add the [`is` operator](0005-is-operator.md) to policies, but an earlier version without that operator may still parse properly. The newer parser can account for this when parsing.
+
+If an input file is annotated with an ill-formed version string, the parser should treat it as a version it does not know about, e.g., as if for a future version of Cedar. It can issue a warning and proceed. If an input file is version-annotated more than once, then the parser should signal an error.
+
+### Policies and Custom Schema
+
+For Cedar policies and custom schema syntax, we propose adding a new top-level declaration:
+```
+__cedar::version(XXX);
+```
+where `XXX` is a string with the version in it.
+
+This declaration applies to all policies or schema elements that are parsed in the same file. It doesn't matter where the declaration is, in the file. If the declaration appears more than once, it is an error.
+
+Here is the amended grammar for a policies file:
+```
+File    := {Policy | Version}
+Version := '__cedar::version' '(' STRING ')' ';'
+Policy  := {Annotation} Effect '(' Scope ')' {Conditions} ';'
+...
+```
+Here is the amended grammar for a custom schema:
+```
+Schema    := {Namespace | Version}
+Version   := '__cedar::version' '(' STRING ')' ';'
+Namespace := ('namespace' Path '{' {Decl} '}') | {Decl}
+...
+```
+In both cases there is the semantic constraint that `VERSION` appears at most once.
+
+### Entities JSON
+
+The Cedar entities JSON is now defined as an array of entity records. We propose to update it to be a record containing a version declaration followed by that array. In particular:
+```
+{
+    "__cedar::version": XXX,
+    "contents": [
+        ...
+    ]
+}
+```
+That is, the `[ ... ]` part above is the same format the parser expects today.
+
+Because version information is optional, the Cedar parser should still accept inputs of the form `[ ... ]`, i.e., a list of entities, assuming they are formatted in accord with the most recent version.
+
+### Schema JSON
+
+The Cedar schema JSON is now defined as a record whose elements are individual namespaces, i.e., 
+```
+{
+    "Name::space::one": {
+        ...
+    },
+    "Name::space::two": {
+        ...
+    }
+}
+```
+We propose to extend this format so that one of the "namespace" elements can be `"__cedar::version"`, and it will be associated with the version string XXX, i.e.,
+```
+{
+    "__cedar::version": XXX, 
+    "Name::space::one": {
+        ...
+    },
+    "Name::space::two": {
+        ...
+    }
+}
+```
+This approach is unambiguous, and optional, because the namespace element `__cedar` is reserved, so no legal schema could define its own namespace containing `__cedar`. (This change was made as part of the [RFC 24](0024-schema-syntax.md).)
+
+## Drawbacks
+
+Implementing this RFC will add some complexity to the various Cedar parsers. They will now have to accept inputs that have a version annotation, and those that do not. They should also use that annotation to improve functionality and/or error messages, but such improvements do not have to come right away.
+
+On the other hand, this RFC is essentially backward compatible -- the old, version-free format will still be accepted (assuming inputs do not rely on changes to format such as [RFC 20](0020-unique-record-keys.md)).
+
+## Alternatives
+
+We could consider versioning individual input elements, rather than whole input files. For example, we could have proposed to use metadata annotations like `@version("2.4.1")` as annotations on individual policies. However, this seems like overkill -- most likely all policies in one batch have the same version; if they do not, you can separate them into multiple batches.
+
+The use of `__cedar::version` as the keyword to identify a version may look a little strange; we might prefer to just write `version` or `cedar_version`. The use of the version key with `__cedar` is crucial for supporting versioning in JSON-based schemas, and for uniformity we thought it best to use the same key everywhere. Also, the presence of `__cedar` in the keyword makes clear that it indicates the _Cedar language_ version, not a version associated with the application using Cedar.


### PR DESCRIPTION
Support version annotations on Cedar inputs.

[Rendered](https://github.com/cedar-policy/rfcs/blob/input-versions/text/0033-input-versions.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
