### PR TITLE
Update timelines

### DIFF
--- a/text/0005-is-operator.md
+++ b/text/0005-is-operator.md
@@ -3,14 +3,14 @@
 ## Related issues and PRs
 
 - Reference Issues: <https://github.com/cedar-policy/cedar/issues/94>
-- Implementation PR(s):
+- Implementation PR(s): <https://github.com/cedar-policy/cedar/pull/396>
 
 ## Timeline
 
 - Started: 2023-06-16
 - Entered FCP (intent to accept): 2023-07-21
 - Accepted: 2023-07-28
-- Landed:
+- Landed: 2023-11-08 on `main`
 
 ## Summary
 

--- a/text/0009-disallow-whitespace-in-entityuid.md
+++ b/text/0009-disallow-whitespace-in-entityuid.md
@@ -3,14 +3,15 @@
 ## Related issues and PRs
 
 - Reference Issues: none
-- Implementation PR(s): https://github.com/cedar-policy/cedar/issues/133
+- Implementation PR(s): <https://github.com/cedar-policy/cedar/pull/134>
 
 ## Timeline
 
 - Started: 2023-06-19
 - Entered FCP (intent to accept): 2023-06-21
 - Accepted: 2023-06-26
-- Landed: 2023-06-29 (included in `cedar-policy` v2.3.0)
+- Landed: 2023-06-28 on `main`
+- Released: 2023-06-29 in `cedar-policy` v2.3.0
 
 ## Summary
 

--- a/text/0019-stricter-validation.md
+++ b/text/0019-stricter-validation.md
@@ -8,7 +8,7 @@
 ## Timeline
 
 - Started: 2023-07-11
-- Entered FCP: 2023-08-18
+- Entered FCP (intent to accept): 2023-08-18
 - Accepted: 2023-09-05
 - Landed: 2023-09-08 on `main`
 

--- a/text/0021-any-and-all-operators.md
+++ b/text/0021-any-and-all-operators.md
@@ -7,10 +7,10 @@
 
 ## Timeline
 
-- Start Date: 2023-07-14
-- Date Entered FCP: 2023-10-27
-- Date Accepted: 2023-11-08
-- Date Landed:
+- Started: 2023-07-14
+- Entered FCP (intent to accept): 2023-10-27
+- Accepted: 2023-11-08
+- Landed:
 
 ## Summary
 

--- a/text/0024-schema-syntax.md
+++ b/text/0024-schema-syntax.md
@@ -7,10 +7,10 @@
 
 ## Timeline
 
-- Start Date: 2023-07-24
-- Date Entered FCP: 2023-08-22
-- Date Accepted: 2023-10-02
-- Date Landed:
+- Started: 2023-07-24
+- Entered FCP (intent to accept): 2023-08-22
+- Accepted: 2023-10-02
+- Landed:
 
 ## Summary
 

--- a/text/0032-port-formalization-to-lean.md
+++ b/text/0032-port-formalization-to-lean.md
@@ -3,14 +3,14 @@
 ## Related issues and PRs
 
 - Reference Issues: N/A
-- Implementation PR(s):
+- Implementation PR(s): <https://github.com/cedar-policy/cedar-spec/pull/138>
 
 ## Timeline
 
 - Started: 2023-10-12
 - Entered FCP (intent to accept): 2023-10-16
-- Accepted: 2023-20-24
-- Landed:
+- Accepted: 2023-10-24
+- Landed: 2023-10-26 on `main`
 
 ## Summary
 


### PR DESCRIPTION
Added "landed" dates and PRs for two RFCs + some minor formatting fixes in other RFCs. Also added a "released" entry for RFC9 (currently our only RFC implemented in a released version of Cedar).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
