### PR TITLE
Changes `IDENT` -> `PATH

### DIFF
--- a/text/0024-schema-syntax.md
+++ b/text/0024-schema-syntax.md
@@ -390,7 +390,7 @@ Decl      := Entity | Action | TypeDecl
 Entity    := 'entity' Idents ['in' EntOrTyps] [['='] RecType] ';'
 Action    := 'action' Names ['in' (Name | '[' [Names] ']')] [AppliesTo] [ActAttrs]';'
 TypeDecl  := 'type' IDENT '=' Type ';'
-Type      := PRIMTYPE | IDENT | SetType | RecType
+Type      := PRIMTYPE | Path | SetType | RecType
 EntType   := Path
 SetType   := 'Set' '<' Type '>'
 RecType   := '{' [AttrDecls] '}'


### PR DESCRIPTION
Small change to the grammar:

The rule for types used to be this:
```
Type      := PRIMTYPE | IDENT | SetType | RecType
```
Where `IDENT` is a pure non-namespaced identifier.
I believe we want `Type` to instead refer to a `Path` which is non-empty list of identifiers separated by `::`


[Rendered](https://github.com/cedar-policy/rfcs/blob/grammar_fixes/text/0024-schema-syntax.md)
