### PR TITLE
Entity slice validation

### DIFF
--- a/text/0068-entity-tags.md
+++ b/text/0068-entity-tags.md
@@ -1,4 +1,4 @@
-# Entity tags
+# Embedded attribute maps
 
 ## Related issues and PRs
 
@@ -15,13 +15,13 @@
 
 ## Summary
 
-This RFC proposes to extend the Cedar type system with the ability to attach _tags_ to entities. Entity tags are a set of key/value pairs with an interface similar to records: keys are like record attributes and values are like attribute values. But unlike records, keys need not be enumerated in advance, as is required with record attributes, and all tag values must have the same type.
+This RFC proposes to extend the Cedar type system with the ability to include _embedded attribute maps_ (EA-maps for short) in entity types. For evaluation purposes, EA-maps have the same programming interface as records: keys are like record attributes and values are like attribute values. The difference is in how they are validated: the keys of EA-maps need not be enumerated in advance, as is required with record attributes, and all values must have the same type. Moreover, EA-maps are treated by the validator as second-class, meaning valid usage scenarios are somewhat restricted.
 
 The main body of this RFC proposes that tag keys must be _literals_ when used to look up a tag's value, just like record attributes, but Alternative A generalizes this proposal to allow keys to be dynamically computed. Alternative A thus adds expressive power but also implementation cost.
 
 ### Basic example
 
-Here is a schema defining two entities, each of which contains entity tags.
+Here is a schema defining two entities, each of which contains embedded attribute maps (EA-maps, for short), used to implement tags.
 ```
 entity User = {
   jobLevel: Long,
@@ -32,7 +32,7 @@ entity Document = {
   policyTags: { ?: Set<String> },
 };
 ```
-The `User` and `Document` entities each have an attribute of type `{ ?: Set<String> }`, identifying tags whose values are sets of strings. The syntax for this type evokes a record, per the curly braces, but without named attributes; by providing just a `?` followed by a colon and a type, we indicate an unspecified number of optional attributes that have values of that type (here, `Set<String>`).
+The `User` and `Document` entities each have an attribute of type `{ ?: Set<String> }`, an EA-map, implementing tags whose values are sets of strings. The syntax for EA-map types evokes a record, per the curly braces, but without named attributes; by providing just a `?` followed by a colon and a type, we indicate an unspecified number of optional attributes that have values of that type (here, `Set<String>`).
 
 Here's a policy that conforms to this schema:
 ```
@@ -48,27 +48,27 @@ when {
     resource.policyTags["write"].containsAny(principal.authTags["write"]))
 };
 ```
-This policy states that for a `User` to carry out the _writeDoc_ action on a `Document`, the user must own the document, or else the user's job level must be at least 6 and the document and the user must each have a `write` tag in their attached tags, where at least one of the user's write-tag's values must be present in the document's write-tag's values.
+This policy states that for a `User` to carry out the _writeDoc_ action on a `Document`, the user must own the document, or else the user's job level must be at least 6 and the document and the user must each have a `write` tag in their EA-maps, where at least one of the user's write-tag's values must be present in the document's write-tag's values.
 
 ## Detailed design
 
-Neither the Cedar evaluator/authorizer, the JSON format for entities, nor the JSON or natural syntax for policies needs to change to support entity tags. This is because tags are represented as records and support the same operations. Only the Cedar schema format, the validator, and the schema-based entity parser need to change to account for a new `{ ?: T }` type.
+Neither the Cedar evaluator/authorizer, the JSON format for entities, nor the JSON or natural syntax for policies needs to change to support embedded attribute maps. This is because the notion of EA-map only arises at validation time, not evaluation time. At evaluation time, EA-maps are represented as records and support the same operations. In other words, for policy writers who do not use validation, there is no need for EA-maps: You can just use records. To support changes to the validator, the Cedar schema format, the validator, and the schema-based entity parser need to change to account for a new `{ ?: T }` type. 
 
 ### Schema
 
-Tags have type `{ ?: T }`, where `T` is the type of tag values. Only entity attributes can be given type `{ ?: T }`, and `T` cannot directly mention another tags type.
+EA-maps have type `{ ?: T }`, where `T` is the type of tag values. Only entity attributes can be given type `{ ?: T }`, and `T` cannot directly mention another EA-maps type.
 
-We extend schemas as follows to support the new tags type. Here's the natural syntax:
+We extend schemas as follows to support the new EA-maps type. Here's the natural syntax:
 ```
 Entity           := 'entity' Idents ['in' EntOrTyps] [['='] EntityRecType] ';'
 EntityRecType    := '{' [EntityAttrDecls] '}'
-EntityAttrDecls  := Name ['?'] ':' [Type | TagsType] [',' | ',' EntityAttrDecls]
-TagsType         := '{' '?' ':' Type '}'
+EntityAttrDecls  := Name ['?'] ':' [Type | EAMapsType] [',' | ',' EntityAttrDecls]
+EAMapsType       := '{' '?' ':' Type '}'
 Type             := PRIMTYPE | Path | SetType | RecType
 ```
-In essence: We alter the definition of entity types to include attributes with type `{ ?: T }`, where `T` is any type not mentioning another tags type. Not shown here are the productions for `RecType` and `AttrDecls`, which apply to records rather than entities. These productions are unchanged---normal records may not include attributes with `{ ?: T }` types.
+In essence: We alter the definition of entity types to include attributes with type `{ ?: T }`, where `T` is any type not mentioning another EA-maps type. Not shown here are the productions for `RecType` and `AttrDecls`, which apply to records rather than entities. These productions are unchanged---normal records may not include attributes with `{ ?: T }` types.
 
-The JSON syntax for schemas specifies tags as records with a `default` element, rather than an `attributes` element. Doing so leverages the analogy that tags are like records in which all attributes are optional, with the same type. Here's our introductory example schema in this format:
+The JSON syntax for schemas specifies EA-maps as records with a `default` element, rather than an `attributes` element. Doing so leverages the analogy that EA-maps are like records in which all attributes are optional, with the same type. Here's our introductory example schema in this format:
 ```
 "entityTypes": {
     "User" : {
@@ -112,9 +112,9 @@ Legal schemas only allow records with `default` to appear as direct entity attri
 
 ### Policies, entities, and evaluation
 
-Tags support all of the same operations as records. Suppose that `E` is an expression of type `{ ?: T }`. Then expression `E has F` will check whether `E` has tag key `F`, evaluating to `true` if so and `false` otherwise. Expression `E.F` or `E["F"]` will retrieve the value associated with key `F` if `F` is present, signaling an error if it is not.
+EA-maps support all of the same operations as records. Suppose that `E` is an expression of type `{ ?: T }`. Then expression `E has F` will check whether `E` has tag key `F`, evaluating to `true` if so and `false` otherwise. Expression `E.F` or `E["F"]` will retrieve the value associated with key `F` if `F` is present, signaling an error if it is not.
 
-As a result, within the evaluator we can represent tags as records, so the evaluator code does not need to change. In particular, tags with keys `F1` ... `Fn` and associated values `V1` .. `Vn` are internally represented as records `{ F1: V1, ..., Fn: Vn }`. Similarly, tags are represented as records in the JSON entity format. For example, here is entity representing `User::"Alice"` which conforms to our example schema:
+As a result, within the evaluator we can represent EA-maps as records, so the evaluator code does not need to change. In particular, EA-maps with keys `F1` ... `Fn` and associated values `V1` .. `Vn` are internally represented as records `{ F1: V1, ..., Fn: Vn }`. Similarly, EA-maps are represented as records in the JSON entity format. For example, here is entity representing `User::"Alice"` which conforms to our example schema:
 ```
     {
         "uid": { "type": "User", "id": "alice" },
@@ -128,17 +128,17 @@ As a result, within the evaluator we can represent tags as records, so the evalu
         "parents": []
     }
 ```
-Note that there is no way to represent a tags _literal_. That is, you cannot write something like `{ write: ["blue", "red"]}` in a policy, like you might for a record literal. This is because tags are always attached to entities, and entities themselves have no literal syntax.
+Note that there is no way to represent a EA-maps _literal_. That is, you cannot write something like `{ write: ["blue", "red"]}` in a policy, like you might for a record literal. This is because EA-maps are always attached to entities, and entities themselves have no literal syntax.
 
 ### Validating policies
 
-We extend the way the policy validator handles optional record attributes in order to support entity tags.
+We extend the way the policy validator handles optional record attributes in order to support embedded attribute maps.
 
 #### Capabilities
 
 Background: While typechecking an expression involving records or entities with optional attributes, the validator tracks _capabilities_. These represent the attribute-accessing expressions that are sure to succeed. If `principal` has type `User` and `User` has an optional `Boolean` attribute `sudo`, then the expression `principal.sudo` only validates if `principal.sudo` is present in the _current capability set_. Capabilities are added to that set by a preceding expression of the form `principal has sudo`, e.g., as in `principal has sudo && principal.sudo`.
 
-Capability tracking must be generalized to support tags. In particular, an entity attribute of type `{ ?: T }` should be treated as a record with optional attributes, and `has` checks on its keys should update the capability set. For our introductory example, consider the following expression
+Capability tracking must be generalized to support EA-maps. In particular, an entity attribute of type `{ ?: T }` should be treated as a record with optional attributes, and `has` checks on its keys should update the capability set. For our introductory example, consider the following expression
 ```
   resource.policyTags has "write" && // (1)
   principal.authTags has "write" &&  // (2)
@@ -148,7 +148,7 @@ After the subexpression (1), `resource.policyTags.write` should be added to the 
 
 #### Limited operations
 
-Tags' second-class status means that tags can only be used as part of checking expressions `E has F` and projection expressions `E.F` or `E[F]`, where `E` has type `{ ?: T }`. The validator should disallow these expressions with type `{ ?: T }` in other contexts; e.g., the following should be disallowed:
+EA-maps' second-class status means that they can only be used as part of checking expressions `E has F` and projection expressions `E.F` or `E[F]`, where `E` has type `{ ?: T }`. The validator should disallow these expressions with type `{ ?: T }` in other contexts; e.g., the following should be disallowed:
 ```
 resource.policyTags == principal.authTags
 [resource.policyTags, principal.authTags]
@@ -158,7 +158,7 @@ resource.policyTags == principal.authTags
 
 ### Validating and parsing entities
 
-The Cedar authorizer's `is_authorized` function can be asked to validate that entities in a request are consistent with a provided schema. Extending validation to work with tags is straightforward. The type rule is basically thus:
+The Cedar authorizer's `is_authorized` function can be asked to validate that entities in a request are consistent with a provided schema. Extending validation to work with EA-maps is straightforward. The type rule is basically thus:
 ```
 v1: T ... vn: T
 ---------------------------------
@@ -174,26 +174,26 @@ Permissive validation supports subtyping, which we extend so as to allow tag typ
 ```
 { ?: T } <: { ?: U }    iff T <: U
 ```
-We might consider adding rules that permit subtyping between records and tags, but doing so introduces some complications with width subtyping. We could choose to grant tags first-class status under permissive validation. For example, we could allow tags values to appear anywhere, e.g., in `Set`s or records, and we could allow equality between tags values. We choose not to do these things for now.
+We might consider adding rules that permit subtyping between records and EA-maps, but doing so introduces some complications with width subtyping. We could choose to grant EA-maps first-class status under permissive validation. For example, we could allow EA-maps values to appear anywhere, e.g., in `Set`s or records, and we could allow equality between EA-maps values. We choose not to do these things for now.
 
 ## Drawbacks
 
 ### Non-dynamic keys
 
-Tags keys must be written in policies as literals. For example, you cannot write the following policy expression (using our example schema from above):
+EA-maps keys must be written in policies as literals. For example, you cannot write the following policy expression (using our example schema from above):
 ```
 principal.authTags has context.key && 
 principal.authTags[context.key] == context.value
 ```
-Supporting such _dynamic keys_ is more work, but doable. With them, `{ ?: T }` tags would be strictly more powerful than existing tag encodings/workarounds. We sketch the needed implementation work in Alternative A, below, and a comparison to workarounds further below.
+Supporting such _dynamic keys_ is more work, but doable. With them, EA-maps would be strictly more powerful than existing tag encodings/workarounds. We sketch the needed implementation work in Alternative A, below, and a comparison to workarounds further below.
 
 ### Second-class status
 
-Only entity attributes are permitted to have type `{ ?: T }`, which eliminates the possibility of `{ ?: T }` literals and tags directly containing other tags. We also forbid using `==` and operations other than `has` and projection on `{ ?: T }`-typed expressions.
+Only entity attributes are permitted to have type `{ ?: T }`, which eliminates the possibility of `{ ?: T }` literals and EA-maps directly containing other EA-maps. We also forbid using `==` and operations other than `has` and projection on `{ ?: T }`-typed expressions.
 
-These restrictions are present for two reasons. First, second-class status ensures tags are efficiently _analyzable_. Allowing first-class tags values would require supporting equality between tags values (directly or indirectly). Supporting equality would require a policy analysis to model tags as arrays imbued with the extensionality axioms, which are known to be expensive. Second, second-class status means that we cannot introduce tags literals, which means we do not need to introduce new syntax for tags, which would be essentially the same as record literal syntax, leading to possible user confusion. Nor do we need to consider how we might treat record literals as equivalent to `{ ?: T }` values.
+These restrictions are present for two reasons. First, second-class status ensures EA-maps are efficiently _analyzable_. Allowing first-class EA-maps values would require supporting equality between EA-maps values (directly or indirectly). Supporting equality would require a policy analysis to model EA-maps as arrays imbued with the extensionality axioms, which are known to be expensive. Second, second-class status means that we cannot introduce EA-maps literals, which means we do not need to introduce new syntax for EA-maps, which would be essentially the same as record literal syntax, leading to possible user confusion. Nor do we need to consider how we might treat record literals as equivalent to `{ ?: T }` values.
 
-The use-cases that we are aware of do not suffer due to these limitations. Typically, you want to attach tags to principals and resources. If you wanted tags to contain other tags, or you wanted to store tags in the `context` record, you can create specific entity types containing only those tags. For example:
+The use-cases that we are aware of do not suffer due to these limitations. Typically, you want to attach EA-maps to principals and resources to act as _tags_. If you wanted EA-maps to contain other EA-maps, or you wanted to store EA-maps in the `context` record, you can create specific entity types containing only those EA-maps. For example:
 ```
 entity User {
     roles: Set<String>,
@@ -207,17 +207,17 @@ In effect, the `User`'s `roleTags` is equivalent to `{ ?: { ?: String } }`, but 
 
 ### Implementation effort
 
-The implementation effort for adding tags is non-trivial, as it will require changing the Rust code, the Lean models and proofs, and the differential test generators. It will also affect any component that leverages the schema and validator algorithms, such as schema-based parsing, and the policy analyzer.
+The implementation effort for adding EA-maps is non-trivial, as it will require changing the Rust code, the Lean models and proofs, and the differential test generators. It will also affect any component that leverages the schema and validator algorithms, such as schema-based parsing, and the policy analyzer.
 
 That said, these changes are relatively straightforward:
 - The validator changes are a straightforward extension to the handling of records with optional attributes. The extension to subtyping for permissive validation is also simple.
-- Changes to entity validation and schema-based parsing are fairly localized: They must consider the new tags type when validating/parsing JSON `Record`-labeled entities.
-- The policy analyzer can model `{ ?: T }` attributes as uninterpreted functions because it never needs to consider equality between `{ ?: T }` values. Equality between entities is _nominal_ -- we just consider the entity UID, not the contents of an entity's mapped-to attribute record (the only place that tags can exist).
+- Changes to entity validation and schema-based parsing are fairly localized: They must consider the new EA-maps type when validating/parsing JSON `Record`-labeled entities.
+- The policy analyzer can model `{ ?: T }` attributes as uninterpreted functions because it never needs to consider equality between `{ ?: T }` values. Equality between entities is _nominal_ -- we just consider the entity UID, not the contents of an entity's mapped-to attribute record (the only place that EA-maps can exist).
 - There are _no_ changes to the evaluator or partial evaluator: From an evaluation perspective, `{ ?: T }` attributes are just attributes containing records whose attributes all have values of type `T`.
 
 ## Alternatives
 
-### Alternative A: Tags with dynamic keys
+### Alternative A: EA-maps with dynamic keys
 
 Supporting dynamic keys (see "Drawbacks: Non-dynamic keys" above), requires a few extensions to the main proposal: to the policy grammar, evaluator (and partial evaluator), validator, and analysis.
 
@@ -260,15 +260,15 @@ Because expressions like `principal has context.name` are now grammatically lega
 
 #### Analysis
 
-The policy analyzer's logical encoding must be generalized to account for keys being specified as expressions rather than as literals. Because we are encoding tags as uninterpreted functions, this presents no problem: it doesn't matter whether the key given to the function is a literal string or an expression that evaluates (is equivalent) to a string. That said, counterexample generation could be a little more involved.
+The policy analyzer's logical encoding must be generalized to account for keys being specified as expressions rather than as literals. Because we are encoding EA-maps as uninterpreted functions, this presents no problem: it doesn't matter whether the key given to the function is a literal string or an expression that evaluates (is equivalent) to a string. That said, counterexample generation could be a little more involved.
 
 #### Summary
 
-There is a tradeoff here. Alternative A is more work to implement than the RFC as given, but not significantly more. And it carries a significant benefit: It enables this notion of tags to be strictly more expressive than both of the workarounds given below, which are modeling tags as optional attributes, and modeling tags as sets of key-value pairs. Anything you can do with either of those workarounds you can do with Alternative A. As a result, policy writers will be encouraged to always use tags directly, which will be easier to manage for policy readers.
+There is a tradeoff here. Alternative A is more work to implement than the RFC as given, but not significantly more. And it carries a significant benefit: It enables this notion of EA-maps to be strictly more expressive than both of the workarounds given below, which are modeling EA-maps as optional attributes, and modeling EA-maps as sets of key-value pairs. Anything you can do with either of those workarounds you can do with Alternative A. As a result, policy writers will be encouraged to always use EA-maps directly, which will be easier to manage for policy readers.
 
 ### Alternative B: Open records
 
-Previously, [RFC 66](https://github.com/cedar-policy/rfcs/pull/66) proposed _open records_ as a generalization of records suitable for encoding tags. Open records are first-class values, however, and so they add far more complication to the implementation effort. See that RFC for further discussion.
+Previously, [RFC 66](https://github.com/cedar-policy/rfcs/pull/66) proposed _open records_ as a generalization of records suitable for encoding tags. Open records are essentially the same as EA-maps, but they are less restrictive, conferring first-class status on values. However, and so they add far more complication to the implementation effort. See that RFC for further discussion.
 
 ### Alternative C: Maps
 
@@ -276,25 +276,23 @@ Another prior RFC, [RFC 27](https://github.com/cedar-policy/rfcs/pull/27), propo
 
 ### Alternative D: Different syntax
 
-Rather than give entity tags the type `{ ?: T }`, we could give them the type `Tags<T>` instead. The drawback is that this type may more strongly suggest that tags can be first class, though they are not. It also fails to evoke the analogy with records, i.e., that tags are a set of key/value pairs, with values all having the same type.
+Rather than give EA-maps the type `{ ?: T }`, we could give them the type `EMap<T>` instead. The drawback is that this type may more strongly suggest that EA-maps can be first class, though they are not. Similarly, we could give EA-maps the type `Map<K,V>` but require `K` to always have type `String`. Doing so may be disappointing to users in that `K` cannot be anything other than `String`, and (once again) `Map` values are not first-class. Both proposals fail to evoke the analogy with records, i.e., that EA-maps are a set of key/value pairs, with values all having the same type.
 
-To avoid potential confusion we could give tags type `{ T }` instead of `{ ?: T }`. The latter syntax could be confusing because `{ "?": T }` is already a legal type for a record with a required attribute `"?"` (thus allowing expressions like `context["?"] == resource.foo`). It might be surprising to users that surrounding `?` in quotes would change the meaning of the type, since types like `{ "name": Long }` and `{ name: Long }` are equivalent. Using syntax `{ T }` would eliminate the potential for a confused interpretation. Nevertheless, the potential for it already exists. Types `{ isPrivate?: Bool }` and `{ "isPrivate?": Bool }` are not the same: The former indicates an optional attribute `isPrivate` whereas the latter indicates a required attribute `"isPrivate?"`. Given this, we prefer syntax `{ ?: T }` since it more directly evokes that entity tags are a kind of record with all-optional attributes, and is no more confusing than the status quo.
-
-Finally, we could give tags the type `Map<K,V>` but require `K` to always have type `String`. Doing so evokes that tags are a kind of map, but may be disappointing to users in that `K` cannot be anything other than `String`, and `Map` values are not first-class.
+To avoid potential confusion we could give EA-maps type `{ T }` instead of `{ ?: T }`. The latter syntax could be confusing because `{ "?": T }` is already a legal type for a record with a required attribute `"?"` (thus allowing expressions like `context["?"] == resource.foo`). It might be surprising to users that surrounding `?` in quotes would change the meaning of the type, since types like `{ "name": Long }` and `{ name: Long }` are equivalent. Using syntax `{ T }` would eliminate the potential for a confused interpretation. Nevertheless, the potential for it already exists. Types `{ isPrivate?: Bool }` and `{ "isPrivate?": Bool }` are not the same: The former indicates an optional attribute `isPrivate` whereas the latter indicates a required attribute `"isPrivate?"`. Given this, we prefer syntax `{ ?: T }` since it more directly evokes that EA-maps are a kind of record with all-optional attributes, and is no more confusing than the status quo.
 
 ### Workaround: Records with optional attributes
 
-We could avoid adding tags entirely and work around their absence.
+We could avoid adding EA-maps entirely and work around their absence.
 
-A direct workaround is to implement tags as a record type that enumerates every legal tag as an optional attribute. Then, every time you create a policy that mentions a tag key as a literal, the validator will complain if that key is not in the schema. So, add the key to the schema, and the new policy will validate along with the old ones.
+A direct workaround is to implement EA-maps as a record type that enumerates every legal tag as an optional attribute. Then, every time you create a policy that mentions a tag key as a literal, the validator will complain if that key is not in the schema. So, add the key to the schema, and the new policy will validate along with the old ones.
 
-The drawback of this approach is that hanging the schema on the fly to extend the list of valid keys could be expensive. If policies are being constructed on the fly, e.g., by a service's users, a schema update to support a new tag used by a new policy would technically require re-validating existing policies, whereas with tags `{ ?: T }` we can leave the schema alone and avoid re-validation entirely.
+The drawback of this approach is that changing the schema on the fly to extend the list of valid keys could be expensive. If policies are being constructed on the fly, e.g., by a service's users, a schema update to support a new tag used by a new policy would technically require re-validating existing policies, whereas with EA-maps `{ ?: T }` we can leave the schema alone and avoid re-validation entirely.
 
 Schemas are also simpler with `{ ?: T }` types, rather than a long list of optional attributes, and better communicate intent.
 
 ### Workaround: Tags as sets of key/value pairs
 
-Another way to implement tags is as sets of key-value pairs. For example, `principal.tags` could have type `Set<{ key:String, value:String }>` and a tag check would involve an expression like `principal.tags.contains({ key: "priority", value: "green" })`.
+Another way to implement tags, rather than as EA-maps, is as sets of key-value pairs. For example, `principal.tags` could have type `Set<{ key:String, value:String }>` and a tag check would involve an expression like `principal.tags.contains({ key: "priority", value: "green" })`.
 
 This approach has the benefit that keys can be dynamic. E.g., you can write
 ```

--- a/text/0068-entity-tags.md
+++ b/text/0068-entity-tags.md
@@ -143,13 +143,15 @@ Capability tracking must be generalized to support tags. In particular, an entit
 ```
 After the subexpression (1), `resource.policyTags.write` should be added to the current capability set. After subexpression (2), `principal.authTags.write` should be added to it. Finally, when validating subexpression (3), the expression `resource.policyTags["write"]` will be considered valid since `resource.policyTags.write` is in the current capability set and it will be given type `Set<String>`, as `resource.policyTags` has type `Tags<Set<String>>`. The expression `principal.authTags["write"]` is handled similarly. If either of the `has` subexpressions (1) or (2) were omitted, subexpression (3) would not validate due to the missing capability set entries.
 
-#### Equality disallowed
+#### Limited operations
 
-The validator will disallow attempts to compare `Tags<T>` attributes. For example, for our example schema the following policy expression will be rejected:
+Tags' second-class status means that expressions of types `Tags<T>` are only permitted as part of `has` and projection expressions (i.e., using `.` or `[]`). The validator should disallow these expressions in other contexts, e.g., the following should be disallowed:
 ```
 resource.policyTags == principal.authTags
+[resource.policyTags, principal.authTags]
+(if true then principal.authTags else principal.authTags).write
 ```
-This goes with tags' second-class status, such that `has` and projection (i.e., using `.` or `[]`) are the only allowed operators.
+(Note that the last case is disallowed because `principal.authTags` and `principal.authTags` are not directly part of a `.` sub-expression -- they are returned from the `if` first.)
 
 ### Validating and parsing entities
 

--- a/text/0068-entity-tags.md
+++ b/text/0068-entity-tags.md
@@ -68,7 +68,7 @@ Type             := PRIMTYPE | Path | SetType | RecType
 ```
 In essence: We alter the definition of entity types to include attributes with type `{ T }`, where `T` is any type not mentioning another tags type. Not shown here are the productions for `RecType` and `AttrDecls`, which apply to records rather than entities. These productions are unchanged---normal records may not include attributes with `{ T }` types.
 
-The JSON syntax for schemas specifies tags as records with a `default` type. Doing so leverages the analogy that tags are like records in which all attributes are optional, with the same type. Here's our introductory example schema in this format:
+The JSON syntax for schemas specifies tags as records with a `default` element, rather than an `attributes` element. Doing so leverages the analogy that tags are like records in which all attributes are optional, with the same type. Here's our introductory example schema in this format:
 ```
 "entityTypes": {
     "User" : {
@@ -80,11 +80,9 @@ The JSON syntax for schemas specifies tags as records with a `default` type. Doi
                 },
                 "authTags" : {
                     "type" : "Record",
-                    "attributes" : {
-                        "default": {
-                            "type" : "Set",
-                            "element": "String"
-                        }
+                    "default": {
+                        "type" : "Set",
+                        "element": "String"
                     }
                 }
             }
@@ -100,11 +98,9 @@ The JSON syntax for schemas specifies tags as records with a `default` type. Doi
                 },
                 "policyTags" : {
                     "type" : "Record",
-                    "attributes" : {
-                        "default": {
-                            "type" : "Set",
-                            "element": "String"
-                        }
+                    "default": {
+                        "type" : "Set",
+                        "element": "String"
                     }
                 }
             }
@@ -112,7 +108,7 @@ The JSON syntax for schemas specifies tags as records with a `default` type. Doi
     }
 }
 ```
-Legal schemas only allow records with `default` to appear as direct entity attributes, and likewise restricts the `type` associated with `default` to not include `default`-containing record types. Record types with a `default` may not have any named attributes.
+Legal schemas only allow records with `default` to appear as direct entity attributes, and likewise restricts the `type` associated with `default` to not include `default`-containing record types. Records with a `default` element cannot also have an `attributes` element (and so cannot have named attributes).
 
 ### Policies, entities, and evaluation
 

--- a/text/0068-entity-tags.md
+++ b/text/0068-entity-tags.md
@@ -165,7 +165,7 @@ In particular, when asked to determine if a record has type `Tags<T>`, we confir
 
 Similarly, schema-based parsing considers schemas when parsing in entities, and it can confirm when parsing that attributes labeled as `Record` in the JSON but defined as `Tags<T>` in the schema have the appropriate shape.
 
-#### Permissive Validation
+### Permissive Validation
 
 Permissive validation supports subtyping, which we extend so as to allow `Tags` types to be treated co-variantly:
 ```
@@ -188,9 +188,9 @@ Supporting dynamic keys is more work, but doable. With them, `Tags<T>` tags woul
 
 ### Second-class status
 
-Only entity attributes are permitted to have type `Tags<T>`, which eliminates the possibility of `Tags<T>` literals and tags directly containing other tags. We also forbid using `==` between `Tags<T>` attributes.
+Only entity attributes are permitted to have type `Tags<T>`, which eliminates the possibility of `Tags<T>` literals and tags directly containing other tags. We also forbid using `==` and operations other than `has` and projection on `Tags<T>`-typed expressions.
 
-These restrictions are present for two reasons. First, second-class status ensures tags are efficiently _analyzable_. Allowing first-class `Tags` values would require supporting equality between `Tags` values. Supporting equality would require policy analysis to model tags as arrays imbued with the extensionality axioms, which are known to be expensive. Second, second-class status means that we cannot introduce `Tags` literals, which means we do not need to introduce new syntax for tags, which would be essentially the same as record literal syntax, leading to user confusion. Nor do we need to consider how we might treat record literals as equivalent to `Tags<T>` values.
+These restrictions are present for two reasons. First, second-class status ensures tags are efficiently _analyzable_. Allowing first-class `Tags` values would require supporting equality between `Tags` values (directly or indirectly). Supporting equality would require policy analysis to model tags as arrays imbued with the extensionality axioms, which are known to be expensive. Second, second-class status means that we cannot introduce `Tags` literals, which means we do not need to introduce new syntax for tags, which would be essentially the same as record literal syntax, leading to user confusion. Nor do we need to consider how we might treat record literals as equivalent to `Tags<T>` values.
 
 The use-cases that we are aware of do not suffer from these limitations. Typically, you want to attach tags to principals and resources. If you wanted tags to contain other tags, or you wanted to store tags in the `context` record, you can create specific entity types containing only those tags. For example:
 ```

--- a/text/0068-entity-tags.md
+++ b/text/0068-entity-tags.md
@@ -15,7 +15,7 @@
 
 ## Summary
 
-This RFC proposes to extend the Cedar type system with the ability to attach _tags_ to entities. Entity tags are similar to records, where keys are like record attributes and values are like attribute values. But keys need not be enumerated in advance, as is required with record attributes, and all values must have the same type.
+This RFC proposes to extend the Cedar type system with the ability to attach _tags_ to entities. Entity tags are a set of key/value pairs with an interface similar to records: keys are like record attributes and values are like attribute values. But unlike records, keys need not be enumerated in advance, as is required with record attributes, and all tag values must have the same type.
 
 The main body of this RFC proposes that tag keys must be _literals_ when used to look up a tag's value, just like record attributes, but Alternative A generalizes this proposal to allow keys to be dynamically computed. Alternative A thus adds expressive power but also implementation cost.
 
@@ -25,14 +25,16 @@ Here is a schema defining two entities, each of which contains entity tags.
 ```
 entity User = {
   jobLevel: Long,
-  authTags: Tags<Set<String>>,
+  authTags: { Set<String>> },
 };
 entity Document = {
   owner: User,
-  policyTags: Tags<Set<String>>, 
+  policyTags: { Set<String> },
 };
 ```
-The `User` and `Document` entities each have an attribute of type `Tags<Set<String>>`, identifying tags whose values are sets of strings. Here's a policy that conforms to this schema:
+The `User` and `Document` entities each have an attribute of type `{ Set<String> }`, identifying tags whose values are sets of strings. The syntax for this type evokes a record, per the curly braces, but without named attributes; by not listing particular attributes and just providing a type, we indicate that all attributes are optional and will have values of the same type (here, `Set<String>`).
+
+Here's a policy that conforms to this schema:
 ```
 permit (
   principal is User,
@@ -50,23 +52,23 @@ This policy states that for a `User` to carry out the _writeDoc_ action on a `Do
 
 ## Detailed design
 
-Neither the Cedar evaluator/authorizer, the JSON format for entities, nor the JSON or natural syntax for policies needs to change to support entity tags. This is because tags are represented as records and support the same operations. Only the Cedar schema format, the validator, and the schema-based entity parser need to change to account for a new `Tags<T>` type.
+Neither the Cedar evaluator/authorizer, the JSON format for entities, nor the JSON or natural syntax for policies needs to change to support entity tags. This is because tags are represented as records and support the same operations. Only the Cedar schema format, the validator, and the schema-based entity parser need to change to account for a new `{ T }` type.
 
 ### Schema
 
-Tags have type `Tags<T>`, where `T` is the type of tag values. Only entity attributes can be given type `Tags<T>`, and `T` cannot directly mention another `Tags` type.
+Tags have type ` { T }`, where `T` is the type of tag values. Only entity attributes can be given type `{ T }`, and `T` cannot directly mention another tags type.
 
-We extend schemas as follows to support the new `Tags` type. Here's the natural syntax:
+We extend schemas as follows to support the new tags type. Here's the natural syntax:
 ```
 Entity           := 'entity' Idents ['in' EntOrTyps] [['='] EntityRecType] ';'
 EntityRecType    := '{' [EntityAttrDecls] '}'
 EntityAttrDecls  := Name ['?'] ':' [Type | TagsType] [',' | ',' EntityAttrDecls]
-TagsType         := 'Tags' '<' Type '>'
+TagsType         := '{' Type '}'
 Type             := PRIMTYPE | Path | SetType | RecType
 ```
-In essence: We alter the definition of entity types to include attributes with type `Tags<T>`, where `T` is any non `Tags`-containing type. Not shown here are the productions for `RecType` and `AttrDecls`, which apply to records rather than entities. These productions are unchanged---normal records may not include attributes with `Tags<T>` types.
+In essence: We alter the definition of entity types to include attributes with type `{ T }`, where `T` is any type not mentioning another tags type. Not shown here are the productions for `RecType` and `AttrDecls`, which apply to records rather than entities. These productions are unchanged---normal records may not include attributes with `{ T }` types.
 
-The JSON syntax for schemas extends the `type` specifier to include `Tags`, for which there is a companion attribute `element`, which is itself a `type`. The JSON syntax parser only permits the `Tags` type to appear in entity attributes, and likewise restricts the `type` associated with `element` to not include `Tags`, itself. Here's our introductory example schema in this format:
+The JSON syntax for schemas specifies tags as records with a `default` type. Doing so leverages the analogy that tags are like records in which all attributes are optional, with the same type. Here's our introductory example schema in this format:
 ```
 "entityTypes": {
     "User" : {
@@ -77,10 +79,12 @@ The JSON syntax for schemas extends the `type` specifier to include `Tags`, for 
                     "type" : "Long"
                 },
                 "authTags" : {
-                    "type" : "Tags",
-                    "element" : {
-                        "type" : "Set",
-                        "element": "String"
+                    "type" : "Record",
+                    "attributes" : {
+                        "default": {
+                            "type" : "Set",
+                            "element": "String"
+                        }
                     }
                 }
             }
@@ -95,10 +99,12 @@ The JSON syntax for schemas extends the `type` specifier to include `Tags`, for 
                     "name" : "User"
                 },
                 "policyTags" : {
-                    "type" : "Tags",
-                    "element" : {
-                        "type" : "Set",
-                        "element": "String"
+                    "type" : "Record",
+                    "attributes" : {
+                        "default": {
+                            "type" : "Set",
+                            "element": "String"
+                        }
                     }
                 }
             }
@@ -106,10 +112,11 @@ The JSON syntax for schemas extends the `type` specifier to include `Tags`, for 
     }
 }
 ```
+Legal schemas only allow records with `default` to appear as direct entity attributes, and likewise restricts the `type` associated with `default` to not include `default`-containing record types. Record types with a `default` may not have any named attributes.
 
 ### Policies, entities, and evaluation
 
-Tags support all of the same operations as records. Suppose that `E` is an expression of type `Tags<T>`. Then expression `E has F` will check whether `E` has tag key `F`, evaluating to `true` if so and `false` otherwise. Expression `E.F` or `E["F"]` will retrieve the value associated with key `F` if `F` is present, signaling an error if it is not.
+Tags support all of the same operations as records. Suppose that `E` is an expression of type `{ T }`. Then expression `E has F` will check whether `E` has tag key `F`, evaluating to `true` if so and `false` otherwise. Expression `E.F` or `E["F"]` will retrieve the value associated with key `F` if `F` is present, signaling an error if it is not.
 
 As a result, within the evaluator we can represent tags as records, so the evaluator code does not need to change. In particular, tags with keys `F1` ... `Fn` and associated values `V1` .. `Vn` are internally represented as records `{ F1: V1, ..., Fn: Vn }`. Similarly, tags are represented as records in the JSON entity format. For example, here is entity representing `User::"Alice"` which conforms to our example schema:
 ```
@@ -125,7 +132,7 @@ As a result, within the evaluator we can represent tags as records, so the evalu
         "parents": []
     }
 ```
-Note that there is no way to represent a `Tags` _literal_. That is, you cannot write something like `{ write: ["blue", "red"]}` in a policy, like you might for a record literal. This is because tags are always attached to entities, and entities themselves have no literal syntax.
+Note that there is no way to represent a tags _literal_. That is, you cannot write something like `{ write: ["blue", "red"]}` in a policy, like you might for a record literal. This is because tags are always attached to entities, and entities themselves have no literal syntax.
 
 ### Validating policies
 
@@ -133,25 +140,25 @@ We extend the way the policy validator handles optional record attributes in ord
 
 #### Capabilities
 
-While typechecking an expression involving records or entities with optional attributes, the validator tracks _capabilities_. These represent the attribute-accessing expressions that are sure to succeed. If `principal` has type `User` and `User` has an optional `Boolean` attribute `sudo`, then the expression `principal.sudo` only validates if `principal.sudo` is present in the _current capability set_. Capabilities are added to that set by a preceding expression of the form `principal has sudo`, e.g., as in `principal has sudo && principal.sudo`.
+Background: While typechecking an expression involving records or entities with optional attributes, the validator tracks _capabilities_. These represent the attribute-accessing expressions that are sure to succeed. If `principal` has type `User` and `User` has an optional `Boolean` attribute `sudo`, then the expression `principal.sudo` only validates if `principal.sudo` is present in the _current capability set_. Capabilities are added to that set by a preceding expression of the form `principal has sudo`, e.g., as in `principal has sudo && principal.sudo`.
 
-Capability tracking must be generalized to support tags. In particular, an entity attribute of type `Tags<T>` should be treated as a record with optional attributes, and `has` checks on its keys should update the capability set. For our introductory example, consider the following the expression 
+Capability tracking must be generalized to support tags. In particular, an entity attribute of type `{ T }` should be treated as a record with optional attributes, and `has` checks on its keys should update the capability set. For our introductory example, consider the following expression 
 ```
   resource.policyTags has "write" && // (1)
   principal.authTags has "write" &&  // (2)
   resource.policyTags["write"].containsAny(principal.authTags["write"]) // (3)
 ```
-After the subexpression (1), `resource.policyTags.write` should be added to the current capability set. After subexpression (2), `principal.authTags.write` should be added to it. Finally, when validating subexpression (3), the expression `resource.policyTags["write"]` will be considered valid since `resource.policyTags.write` is in the current capability set and it will be given type `Set<String>`, as `resource.policyTags` has type `Tags<Set<String>>`. The expression `principal.authTags["write"]` is handled similarly. If either of the `has` subexpressions (1) or (2) were omitted, subexpression (3) would not validate due to the missing capability set entries.
+After the subexpression (1), `resource.policyTags.write` should be added to the current capability set. After subexpression (2), `principal.authTags.write` should be added to it. Finally, when validating subexpression (3), the expression `resource.policyTags["write"]` will be considered valid since `resource.policyTags.write` is in the current capability set and it will be given type `Set<String>`, as `resource.policyTags` has type `{ Set<String> }`. The expression `principal.authTags["write"]` is handled similarly. If either of the `has` subexpressions (1) or (2) were omitted, subexpression (3) would not validate due to the missing capability set entries.
 
 #### Limited operations
 
-Tags' second-class status means that expressions of types `Tags<T>` are only permitted as part of `has` and projection expressions (i.e., using `.` or `[]`). The validator should disallow these expressions in other contexts, e.g., the following should be disallowed:
+Tags' second-class status means that tags can only be used as part of checking expressions `E has F` and projection expressions `E.F` or `E[F]`, where `E` has type `{ T }`. The validator should disallow these expressions with type `{ T }` in other contexts; e.g., the following should be disallowed:
 ```
 resource.policyTags == principal.authTags
 [resource.policyTags, principal.authTags]
 (if true then principal.authTags else principal.authTags).write
 ```
-(Note that the last case is disallowed because `principal.authTags` and `principal.authTags` are not directly part of a `.` sub-expression -- they are returned from the `if` first.)
+(Note that the last case is disallowed because `principal.authTags` is not _directly_ part of a `.` sub-expression -- it is returned from the `if` first.)
 
 ### Validating and parsing entities
 
@@ -159,50 +166,48 @@ The Cedar authorizer's `is_authorized` function can be asked to validate that en
 ```
 v1: T ... vn: T
 ---------------------------------
-{ f1: v1, ..., fn: vn } : Tags<T>
+{ f1: v1, ..., fn: vn } : { T }
 ```
-In particular, when asked to determine if a record has type `Tags<T>`, we confirm that all values in the record have type `T`. By the nature of restrictions on schemas, the validator will only ever consider `Tags<T>` types associated with entity attributes.
+In particular, when asked to determine if a record has type `{ T }`, we confirm that all values in the record have type `T`. By the nature of restrictions on schemas, the validator will only ever consider `{ T }` types associated with entity attributes.
 
-Similarly, schema-based parsing considers schemas when parsing in entities, and it can confirm when parsing that attributes labeled as `Record` in the JSON but defined as `Tags<T>` in the schema have the appropriate shape.
+Similarly, schema-based parsing considers schemas when parsing in entities, and it can confirm when parsing that attributes labeled as `Record` in the JSON but defined as `{ T }` in the schema have the appropriate shape.
 
 ### Permissive Validation
 
-Permissive validation supports subtyping, which we extend so as to allow `Tags` types to be treated co-variantly:
+Permissive validation supports subtyping, which we extend so as to allow tags types to be treated co-variantly:
 ```
-Tags<T> <: Tags<U>    iff T <: U
+{ T } <: { U }    iff T <: U
 ```
-We might consider adding rules that permit subtyping between records and tags, but doing so introduces some complications with width subtyping.
-
-We could choose to grant `Tags` first-class status under permissive validation. For example, we could allow `Tags` values to appear anywhere, e.g., in `Set`s or records, and we could allow equality between `Tags` values. We choose not to do this for now, but may revisit in the future.
+We might consider adding rules that permit subtyping between records and tags, but doing so introduces some complications with width subtyping. We could choose to grant tags first-class status under permissive validation. For example, we could allow tags values to appear anywhere, e.g., in `Set`s or records, and we could allow equality between tags values. We choose not to do these things for now.
 
 ## Drawbacks
 
 ### Non-dynamic keys
 
-`Tags<T>` attributes require keys to be statically identified in policies, as literals. For example, you cannot write the following policy expression (using our example schema from above):
+Tags keys must be written in policies as literals. For example, you cannot write the following policy expression (using our example schema from above):
 ```
 principal.authTags has context.key && 
 principal.authTags[context.key] == context.value
 ```
-Supporting dynamic keys is more work, but doable. With them, `Tags<T>` tags would be strictly more powerful than existing tag encodings/workarounds. We sketch the needed implementation work in Alternative A, below, and a comparison to workarounds further below.
+Supporting such _dynamic keys_ is more work, but doable. With them, `{ T }` tags would be strictly more powerful than existing tag encodings/workarounds. We sketch the needed implementation work in Alternative A, below, and a comparison to workarounds further below.
 
 ### Second-class status
 
-Only entity attributes are permitted to have type `Tags<T>`, which eliminates the possibility of `Tags<T>` literals and tags directly containing other tags. We also forbid using `==` and operations other than `has` and projection on `Tags<T>`-typed expressions.
+Only entity attributes are permitted to have type `{ T }`, which eliminates the possibility of `{ T }` literals and tags directly containing other tags. We also forbid using `==` and operations other than `has` and projection on `{ T }`-typed expressions.
 
-These restrictions are present for two reasons. First, second-class status ensures tags are efficiently _analyzable_. Allowing first-class `Tags` values would require supporting equality between `Tags` values (directly or indirectly). Supporting equality would require policy analysis to model tags as arrays imbued with the extensionality axioms, which are known to be expensive. Second, second-class status means that we cannot introduce `Tags` literals, which means we do not need to introduce new syntax for tags, which would be essentially the same as record literal syntax, leading to user confusion. Nor do we need to consider how we might treat record literals as equivalent to `Tags<T>` values.
+These restrictions are present for two reasons. First, second-class status ensures tags are efficiently _analyzable_. Allowing first-class tags values would require supporting equality between tags values (directly or indirectly). Supporting equality would require a policy analysis to model tags as arrays imbued with the extensionality axioms, which are known to be expensive. Second, second-class status means that we cannot introduce tags literals, which means we do not need to introduce new syntax for tags, which would be essentially the same as record literal syntax, leading to possible user confusion. Nor do we need to consider how we might treat record literals as equivalent to `{ T }` values.
 
-The use-cases that we are aware of do not suffer from these limitations. Typically, you want to attach tags to principals and resources. If you wanted tags to contain other tags, or you wanted to store tags in the `context` record, you can create specific entity types containing only those tags. For example:
+The use-cases that we are aware of do not suffer due to these limitations. Typically, you want to attach tags to principals and resources. If you wanted tags to contain other tags, or you wanted to store tags in the `context` record, you can create specific entity types containing only those tags. For example:
 ```
 entity User {
     roles: Set<String>,
-    roleTags: Tags<StringTags>,
+    roleTags: { StringTags },
 };
 entity StringTags {
-    tags: Tags<String>
+    tags: { String }
 };
 ```
-In effect, the `User`'s `roleTags` is equivalent to `Tags<Tags<String>>`, but we have added a level of indirection by expressing the inner `Tags<String>` value as an entity with a `Tags<String>` attribute.
+In effect, the `User`'s `roleTags` is equivalent to `{ { String } }`, but we have added a level of indirection by expressing the inner `{ String }` value as an entity with a `{ String }` attribute.
 
 ### Implementation effort
 
@@ -210,9 +215,9 @@ The implementation effort for adding tags is non-trivial, as it will require cha
 
 That said, these changes are relatively straightforward:
 - The validator changes are a straightforward extension to the handling of records with optional attributes. The extension to subtyping for permissive validation is also simple.
-- Changes to entity validation and schema-based parsing are fairly localized: They must consider the new `Tags` type when validating/parsing JSON `Record`-labeled entities.
-- The policy analyzer can model `Tags<T>` attributes as uninterpreted functions because it never needs to consider equality between `Tags<T>` values. Equality between entities is _nominal_ -- we just consider the entity UID, not the contents of an entity's mapped-to attribute record (the only place that tags can exist).
-- There are _no_ changes to the evaluator or partial evaluator: From an evaluation perspective, `Tags<T>` attributes are just attributes containing records whose attributes all have values of type `T`.
+- Changes to entity validation and schema-based parsing are fairly localized: They must consider the new tags type when validating/parsing JSON `Record`-labeled entities.
+- The policy analyzer can model `{ T }` attributes as uninterpreted functions because it never needs to consider equality between `{ T }` values. Equality between entities is _nominal_ -- we just consider the entity UID, not the contents of an entity's mapped-to attribute record (the only place that tags can exist).
+- There are _no_ changes to the evaluator or partial evaluator: From an evaluation perspective, `{ T }` attributes are just attributes containing records whose attributes all have values of type `T`.
 
 ## Alternatives
 
@@ -255,7 +260,7 @@ The validator must change to further extend capability tracking from what we've 
 
 In addition, it's now possible that an attribute-constructing expression could access a bogus attribute, so those expressions must be validated as well. E.g., when validating `principal.tags has resource.name` or `principal.tags[resource.name]`, the validator must confirm that `resource` indeed has a `name` attribute.
 
-Because expressions like `principal has context.name` are now grammatically legal, the validator must be updated to consider them fully. In partcular, the validator should only allow `F` to be an expression when writing `E has F` or `E[F]` if `E` has type `Tags<T>`---it will not be allowed when `E` has a normal record or entity type.
+Because expressions like `principal has context.name` are now grammatically legal, the validator must be updated to consider them fully. In partcular, the validator should only allow `F` to be an expression when writing `E has F` or `E[F]` if `E` has type `{ T }`---it will not be allowed when `E` has a normal record or entity type.
 
 #### Analysis
 
@@ -263,7 +268,7 @@ The policy analyzer's logical encoding must be generalized to account for keys b
 
 #### Summary
 
-There is a tradeoff here. Alternative A is more work to implement than the RFC as given, but not significantly more. And it carries a significant benefit: It enables this notion of tags to be strictly more expressive than both of the workarounds given below, which are modeling tags as optional attributes, and modeling tags as sets of key-value pairs. Anything you can do with either of those workarounds you can do with Alternative A. As a result, policy writers will be encouraged to always use `Tags` directly, which will be easier to manage for policy readers.
+There is a tradeoff here. Alternative A is more work to implement than the RFC as given, but not significantly more. And it carries a significant benefit: It enables this notion of tags to be strictly more expressive than both of the workarounds given below, which are modeling tags as optional attributes, and modeling tags as sets of key-value pairs. Anything you can do with either of those workarounds you can do with Alternative A. As a result, policy writers will be encouraged to always use tags directly, which will be easier to manage for policy readers.
 
 ### Alternative B: Open records
 
@@ -271,7 +276,15 @@ Previously, [RFC 66](https://github.com/cedar-policy/rfcs/pull/66) proposed _ope
 
 ### Alternative C: Maps
 
-Another prior RFC, [RFC 27](https://github.com/cedar-policy/rfcs/pull/27), proposed to create `map<T>` types as alternative types for records whose attributes all have the same type `T`, and whose attributes can be dynamically constructed (like dynamic keys for Alternative A, above). That RFC's `map<T>` type is quite similar to this RFC's `tags<T>` type except that maps are not second-class, and support dynamic keys. Supporting maps would lead to even greater implementation challenges than open records, per discussion on both of those prior RFCs.
+Another prior RFC, [RFC 27](https://github.com/cedar-policy/rfcs/pull/27), proposed to create `map<T>` types as alternative types for records whose attributes all have the same type `T`, and whose attributes can be dynamically constructed (like dynamic keys for Alternative A, above). That RFC's `map<T>` type is quite similar to this RFC's `{ T }` type except that maps are not second-class, and support dynamic keys. Supporting maps would lead to even greater implementation challenges than open records, per discussion on both of those prior RFCs.
+
+### Alternative D: Different syntax
+
+Rather than give entity tags the type `{ T }`, we could give them the type `Tags<T>` instead. The drawback is that this type may more strongly suggest that tags can be first class, though they are not. It also fails to evoke the analogy with records, i.e., that tags are a set of key/value pairs, with values all having the same type.
+
+To more closely evoke that tags are like records with optional attributes, we might give them the type `{ ?: T }` or even `{ *?: T }` instead. This syntax implies that attributes of the record are unnamed, and all have the same type. The problem is that `?` and `*?` are legal attribute names, so there is ambiguity with this type and the types `{ "?": T }` and `{ "*?": T }`. The proposed type `{ T }` avoids this ambiguity.
+
+Finally, we could give tags the type `Map<K,V>` but require `K` to always have type `String`. Doing so evokes that tags are a kind of map, but may be disappointing to users in that `K` cannot be anything other than `String`, and `Map` values are not first-class.
 
 ### Workaround: Records with optional attributes
 
@@ -279,9 +292,9 @@ We could avoid adding tags entirely and work around their absence.
 
 A direct workaround is to implement tags as a record type that enumerates every legal tag as an optional attribute. Then, every time you create a policy that mentions a tag key as a literal, the validator will complain if that key is not in the schema. So, add the key to the schema, and the new policy will validate along with the old ones.
 
-The drawback of this approach is that hanging the schema on the fly to extend the list of valid keys could be expensive. If policies are being constructed on the fly, e.g., by a service's users, a schema update to support a new tag used by a new policy would technically require re-validating existing policies, whereas with open `Tags<T>` values we can leave the schema alone and avoid re-validation entirely.
+The drawback of this approach is that hanging the schema on the fly to extend the list of valid keys could be expensive. If policies are being constructed on the fly, e.g., by a service's users, a schema update to support a new tag used by a new policy would technically require re-validating existing policies, whereas with tags `{ T }` we can leave the schema alone and avoid re-validation entirely.
 
-Schemas are also simpler with `Tags<T>` types, rather than a long list of optional attributes, and better communicate intent.
+Schemas are also simpler with `{ T }` types, rather than a long list of optional attributes, and better communicate intent.
 
 ### Workaround: Tags as sets of key/value pairs
 

--- a/text/0068-entity-tags.md
+++ b/text/0068-entity-tags.md
@@ -25,14 +25,14 @@ Here is a schema defining two entities, each of which contains entity tags.
 ```
 entity User = {
   jobLevel: Long,
-  authTags: { Set<String>> },
+  authTags: { ?: Set<String> },
 };
 entity Document = {
   owner: User,
-  policyTags: { Set<String> },
+  policyTags: { ?: Set<String> },
 };
 ```
-The `User` and `Document` entities each have an attribute of type `{ Set<String> }`, identifying tags whose values are sets of strings. The syntax for this type evokes a record, per the curly braces, but without named attributes; by not listing particular attributes and just providing a type, we indicate that all attributes are optional and will have values of the same type (here, `Set<String>`).
+The `User` and `Document` entities each have an attribute of type `{ ?: Set<String> }`, identifying tags whose values are sets of strings. The syntax for this type evokes a record, per the curly braces, but without named attributes; by providing just a `?` followed by a colon and a type, we indicate an unspecified number of optional attributes that have values of that type (here, `Set<String>`).
 
 Here's a policy that conforms to this schema:
 ```
@@ -52,21 +52,21 @@ This policy states that for a `User` to carry out the _writeDoc_ action on a `Do
 
 ## Detailed design
 
-Neither the Cedar evaluator/authorizer, the JSON format for entities, nor the JSON or natural syntax for policies needs to change to support entity tags. This is because tags are represented as records and support the same operations. Only the Cedar schema format, the validator, and the schema-based entity parser need to change to account for a new `{ T }` type.
+Neither the Cedar evaluator/authorizer, the JSON format for entities, nor the JSON or natural syntax for policies needs to change to support entity tags. This is because tags are represented as records and support the same operations. Only the Cedar schema format, the validator, and the schema-based entity parser need to change to account for a new `{ ?: T }` type.
 
 ### Schema
 
-Tags have type ` { T }`, where `T` is the type of tag values. Only entity attributes can be given type `{ T }`, and `T` cannot directly mention another tags type.
+Tags have type `{ ?: T }`, where `T` is the type of tag values. Only entity attributes can be given type `{ ?: T }`, and `T` cannot directly mention another tags type.
 
 We extend schemas as follows to support the new tags type. Here's the natural syntax:
 ```
 Entity           := 'entity' Idents ['in' EntOrTyps] [['='] EntityRecType] ';'
 EntityRecType    := '{' [EntityAttrDecls] '}'
 EntityAttrDecls  := Name ['?'] ':' [Type | TagsType] [',' | ',' EntityAttrDecls]
-TagsType         := '{' Type '}'
+TagsType         := '{' '?' ':' Type '}'
 Type             := PRIMTYPE | Path | SetType | RecType
 ```
-In essence: We alter the definition of entity types to include attributes with type `{ T }`, where `T` is any type not mentioning another tags type. Not shown here are the productions for `RecType` and `AttrDecls`, which apply to records rather than entities. These productions are unchanged---normal records may not include attributes with `{ T }` types.
+In essence: We alter the definition of entity types to include attributes with type `{ ?: T }`, where `T` is any type not mentioning another tags type. Not shown here are the productions for `RecType` and `AttrDecls`, which apply to records rather than entities. These productions are unchanged---normal records may not include attributes with `{ ?: T }` types.
 
 The JSON syntax for schemas specifies tags as records with a `default` element, rather than an `attributes` element. Doing so leverages the analogy that tags are like records in which all attributes are optional, with the same type. Here's our introductory example schema in this format:
 ```
@@ -112,7 +112,7 @@ Legal schemas only allow records with `default` to appear as direct entity attri
 
 ### Policies, entities, and evaluation
 
-Tags support all of the same operations as records. Suppose that `E` is an expression of type `{ T }`. Then expression `E has F` will check whether `E` has tag key `F`, evaluating to `true` if so and `false` otherwise. Expression `E.F` or `E["F"]` will retrieve the value associated with key `F` if `F` is present, signaling an error if it is not.
+Tags support all of the same operations as records. Suppose that `E` is an expression of type `{ ?: T }`. Then expression `E has F` will check whether `E` has tag key `F`, evaluating to `true` if so and `false` otherwise. Expression `E.F` or `E["F"]` will retrieve the value associated with key `F` if `F` is present, signaling an error if it is not.
 
 As a result, within the evaluator we can represent tags as records, so the evaluator code does not need to change. In particular, tags with keys `F1` ... `Fn` and associated values `V1` .. `Vn` are internally represented as records `{ F1: V1, ..., Fn: Vn }`. Similarly, tags are represented as records in the JSON entity format. For example, here is entity representing `User::"Alice"` which conforms to our example schema:
 ```
@@ -138,17 +138,17 @@ We extend the way the policy validator handles optional record attributes in ord
 
 Background: While typechecking an expression involving records or entities with optional attributes, the validator tracks _capabilities_. These represent the attribute-accessing expressions that are sure to succeed. If `principal` has type `User` and `User` has an optional `Boolean` attribute `sudo`, then the expression `principal.sudo` only validates if `principal.sudo` is present in the _current capability set_. Capabilities are added to that set by a preceding expression of the form `principal has sudo`, e.g., as in `principal has sudo && principal.sudo`.
 
-Capability tracking must be generalized to support tags. In particular, an entity attribute of type `{ T }` should be treated as a record with optional attributes, and `has` checks on its keys should update the capability set. For our introductory example, consider the following expression 
+Capability tracking must be generalized to support tags. In particular, an entity attribute of type `{ ?: T }` should be treated as a record with optional attributes, and `has` checks on its keys should update the capability set. For our introductory example, consider the following expression
 ```
   resource.policyTags has "write" && // (1)
   principal.authTags has "write" &&  // (2)
   resource.policyTags["write"].containsAny(principal.authTags["write"]) // (3)
 ```
-After the subexpression (1), `resource.policyTags.write` should be added to the current capability set. After subexpression (2), `principal.authTags.write` should be added to it. Finally, when validating subexpression (3), the expression `resource.policyTags["write"]` will be considered valid since `resource.policyTags.write` is in the current capability set and it will be given type `Set<String>`, as `resource.policyTags` has type `{ Set<String> }`. The expression `principal.authTags["write"]` is handled similarly. If either of the `has` subexpressions (1) or (2) were omitted, subexpression (3) would not validate due to the missing capability set entries.
+After the subexpression (1), `resource.policyTags.write` should be added to the current capability set. After subexpression (2), `principal.authTags.write` should be added to it. Finally, when validating subexpression (3), the expression `resource.policyTags["write"]` will be considered valid since `resource.policyTags.write` is in the current capability set and it will be given type `Set<String>`, as `resource.policyTags` has type `{ ?: Set<String> }`. The expression `principal.authTags["write"]` is handled similarly. If either of the `has` subexpressions (1) or (2) were omitted, subexpression (3) would not validate due to the missing capability set entries.
 
 #### Limited operations
 
-Tags' second-class status means that tags can only be used as part of checking expressions `E has F` and projection expressions `E.F` or `E[F]`, where `E` has type `{ T }`. The validator should disallow these expressions with type `{ T }` in other contexts; e.g., the following should be disallowed:
+Tags' second-class status means that tags can only be used as part of checking expressions `E has F` and projection expressions `E.F` or `E[F]`, where `E` has type `{ ?: T }`. The validator should disallow these expressions with type `{ ?: T }` in other contexts; e.g., the following should be disallowed:
 ```
 resource.policyTags == principal.authTags
 [resource.policyTags, principal.authTags]
@@ -162,17 +162,17 @@ The Cedar authorizer's `is_authorized` function can be asked to validate that en
 ```
 v1: T ... vn: T
 ---------------------------------
-{ f1: v1, ..., fn: vn } : { T }
+{ f1: v1, ..., fn: vn } : { ?: T }
 ```
-In particular, when asked to determine if a record has type `{ T }`, we confirm that all values in the record have type `T`. By the nature of restrictions on schemas, the validator will only ever consider `{ T }` types associated with entity attributes.
+In particular, when asked to determine if a record has type `{ ?: T }`, we confirm that all values in the record have type `T`. By the nature of restrictions on schemas, the validator will only ever consider `{ ?: T }` types associated with entity attributes.
 
-Similarly, schema-based parsing considers schemas when parsing in entities, and it can confirm when parsing that attributes labeled as `Record` in the JSON but defined as `{ T }` in the schema have the appropriate shape.
+Similarly, schema-based parsing considers schemas when parsing in entities, and it can confirm when parsing that attributes labeled as `Record` in the JSON but defined as `{ ?: T }` in the schema have the appropriate shape.
 
 ### Permissive Validation
 
 Permissive validation supports subtyping, which we extend so as to allow tags types to be treated co-variantly:
 ```
-{ T } <: { U }    iff T <: U
+{ ?: T } <: { U }    iff T <: U
 ```
 We might consider adding rules that permit subtyping between records and tags, but doing so introduces some complications with width subtyping. We could choose to grant tags first-class status under permissive validation. For example, we could allow tags values to appear anywhere, e.g., in `Set`s or records, and we could allow equality between tags values. We choose not to do these things for now.
 
@@ -185,25 +185,25 @@ Tags keys must be written in policies as literals. For example, you cannot write
 principal.authTags has context.key && 
 principal.authTags[context.key] == context.value
 ```
-Supporting such _dynamic keys_ is more work, but doable. With them, `{ T }` tags would be strictly more powerful than existing tag encodings/workarounds. We sketch the needed implementation work in Alternative A, below, and a comparison to workarounds further below.
+Supporting such _dynamic keys_ is more work, but doable. With them, `{ ?: T }` tags would be strictly more powerful than existing tag encodings/workarounds. We sketch the needed implementation work in Alternative A, below, and a comparison to workarounds further below.
 
 ### Second-class status
 
-Only entity attributes are permitted to have type `{ T }`, which eliminates the possibility of `{ T }` literals and tags directly containing other tags. We also forbid using `==` and operations other than `has` and projection on `{ T }`-typed expressions.
+Only entity attributes are permitted to have type `{ ?: T }`, which eliminates the possibility of `{ ?: T }` literals and tags directly containing other tags. We also forbid using `==` and operations other than `has` and projection on `{ ?: T }`-typed expressions.
 
-These restrictions are present for two reasons. First, second-class status ensures tags are efficiently _analyzable_. Allowing first-class tags values would require supporting equality between tags values (directly or indirectly). Supporting equality would require a policy analysis to model tags as arrays imbued with the extensionality axioms, which are known to be expensive. Second, second-class status means that we cannot introduce tags literals, which means we do not need to introduce new syntax for tags, which would be essentially the same as record literal syntax, leading to possible user confusion. Nor do we need to consider how we might treat record literals as equivalent to `{ T }` values.
+These restrictions are present for two reasons. First, second-class status ensures tags are efficiently _analyzable_. Allowing first-class tags values would require supporting equality between tags values (directly or indirectly). Supporting equality would require a policy analysis to model tags as arrays imbued with the extensionality axioms, which are known to be expensive. Second, second-class status means that we cannot introduce tags literals, which means we do not need to introduce new syntax for tags, which would be essentially the same as record literal syntax, leading to possible user confusion. Nor do we need to consider how we might treat record literals as equivalent to `{ ?: T }` values.
 
 The use-cases that we are aware of do not suffer due to these limitations. Typically, you want to attach tags to principals and resources. If you wanted tags to contain other tags, or you wanted to store tags in the `context` record, you can create specific entity types containing only those tags. For example:
 ```
 entity User {
     roles: Set<String>,
-    roleTags: { StringTags },
+    roleTags: { ?: StringTags },
 };
 entity StringTags {
-    tags: { String }
+    tags: { ?: String }
 };
 ```
-In effect, the `User`'s `roleTags` is equivalent to `{ { String } }`, but we have added a level of indirection by expressing the inner `{ String }` value as an entity with a `{ String }` attribute.
+In effect, the `User`'s `roleTags` is equivalent to `{ ?: { ?: String } }`, but we have added a level of indirection by expressing the inner `{ ?: String }` value as an entity with a `{ ?: String }` attribute.
 
 ### Implementation effort
 
@@ -212,8 +212,8 @@ The implementation effort for adding tags is non-trivial, as it will require cha
 That said, these changes are relatively straightforward:
 - The validator changes are a straightforward extension to the handling of records with optional attributes. The extension to subtyping for permissive validation is also simple.
 - Changes to entity validation and schema-based parsing are fairly localized: They must consider the new tags type when validating/parsing JSON `Record`-labeled entities.
-- The policy analyzer can model `{ T }` attributes as uninterpreted functions because it never needs to consider equality between `{ T }` values. Equality between entities is _nominal_ -- we just consider the entity UID, not the contents of an entity's mapped-to attribute record (the only place that tags can exist).
-- There are _no_ changes to the evaluator or partial evaluator: From an evaluation perspective, `{ T }` attributes are just attributes containing records whose attributes all have values of type `T`.
+- The policy analyzer can model `{ ?: T }` attributes as uninterpreted functions because it never needs to consider equality between `{ ?: T }` values. Equality between entities is _nominal_ -- we just consider the entity UID, not the contents of an entity's mapped-to attribute record (the only place that tags can exist).
+- There are _no_ changes to the evaluator or partial evaluator: From an evaluation perspective, `{ ?: T }` attributes are just attributes containing records whose attributes all have values of type `T`.
 
 ## Alternatives
 
@@ -256,7 +256,7 @@ The validator must change to further extend capability tracking from what we've 
 
 In addition, it's now possible that an attribute-constructing expression could access a bogus attribute, so those expressions must be validated as well. E.g., when validating `principal.tags has resource.name` or `principal.tags[resource.name]`, the validator must confirm that `resource` indeed has a `name` attribute.
 
-Because expressions like `principal has context.name` are now grammatically legal, the validator must be updated to consider them fully. In partcular, the validator should only allow `F` to be an expression when writing `E has F` or `E[F]` if `E` has type `{ T }`---it will not be allowed when `E` has a normal record or entity type.
+Because expressions like `principal has context.name` are now grammatically legal, the validator must be updated to consider them fully. In partcular, the validator should only allow `F` to be an expression when writing `E has F` or `E[F]` if `E` has type `{ ?: T }`---it will not be allowed when `E` has a normal record or entity type.
 
 #### Analysis
 
@@ -272,13 +272,13 @@ Previously, [RFC 66](https://github.com/cedar-policy/rfcs/pull/66) proposed _ope
 
 ### Alternative C: Maps
 
-Another prior RFC, [RFC 27](https://github.com/cedar-policy/rfcs/pull/27), proposed to create `map<T>` types as alternative types for records whose attributes all have the same type `T`, and whose attributes can be dynamically constructed (like dynamic keys for Alternative A, above). That RFC's `map<T>` type is quite similar to this RFC's `{ T }` type except that maps are not second-class, and support dynamic keys. Supporting maps would lead to even greater implementation challenges than open records, per discussion on both of those prior RFCs.
+Another prior RFC, [RFC 27](https://github.com/cedar-policy/rfcs/pull/27), proposed to create `map<T>` types as alternative types for records whose attributes all have the same type `T`, and whose attributes can be dynamically constructed (like dynamic keys for Alternative A, above). That RFC's `map<T>` type is quite similar to this RFC's `{ ?: T }` type except that maps are not second-class, and support dynamic keys. Supporting maps would lead to even greater implementation challenges than open records, per discussion on both of those prior RFCs.
 
 ### Alternative D: Different syntax
 
-Rather than give entity tags the type `{ T }`, we could give them the type `Tags<T>` instead. The drawback is that this type may more strongly suggest that tags can be first class, though they are not. It also fails to evoke the analogy with records, i.e., that tags are a set of key/value pairs, with values all having the same type.
+Rather than give entity tags the type `{ ?: T }`, we could give them the type `Tags<T>` instead. The drawback is that this type may more strongly suggest that tags can be first class, though they are not. It also fails to evoke the analogy with records, i.e., that tags are a set of key/value pairs, with values all having the same type.
 
-To more closely evoke that tags are like records with optional attributes, we might give them the type `{ ?: T }` or even `{ *?: T }` instead. This syntax implies that attributes of the record are unnamed, and all have the same type. The problem is that `?` and `*?` are legal attribute names, so there is ambiguity with this type and the types `{ "?": T }` and `{ "*?": T }`. The proposed type `{ T }` avoids this ambiguity.
+To avoid potential confusion we could give tags type `{ T }` instead of `{ ?: T }`. The latter syntax could be confusing because `{ "?": T }` is already a legal type for a record with a required attribute `"?"` (thus allowing expressions like `context["?"] == resource.foo`). It might be surprising to users that surrounding `?` in quotes would change the meaning of the type, since types like `{ "name": Long }` and `{ name: Long }` are equivalent. Using syntax `{ T }` would eliminate the potential for a confused interpretation. Nevertheless, the potential for it already exists. Types `{ isPrivate?: Bool }` and `{ "isPrivate?": Bool }` are not the same: The former indicates an optional attribute `isPrivate` whereas the latter indicates a required attribute `"isPrivate?"`. Given this, we prefer syntax `{ ?: T }` since it more directly evokes that entity tags are a kind of record with all-optional attributes, and is no more confusing than the status quo.
 
 Finally, we could give tags the type `Map<K,V>` but require `K` to always have type `String`. Doing so evokes that tags are a kind of map, but may be disappointing to users in that `K` cannot be anything other than `String`, and `Map` values are not first-class.
 
@@ -288,9 +288,9 @@ We could avoid adding tags entirely and work around their absence.
 
 A direct workaround is to implement tags as a record type that enumerates every legal tag as an optional attribute. Then, every time you create a policy that mentions a tag key as a literal, the validator will complain if that key is not in the schema. So, add the key to the schema, and the new policy will validate along with the old ones.
 
-The drawback of this approach is that hanging the schema on the fly to extend the list of valid keys could be expensive. If policies are being constructed on the fly, e.g., by a service's users, a schema update to support a new tag used by a new policy would technically require re-validating existing policies, whereas with tags `{ T }` we can leave the schema alone and avoid re-validation entirely.
+The drawback of this approach is that hanging the schema on the fly to extend the list of valid keys could be expensive. If policies are being constructed on the fly, e.g., by a service's users, a schema update to support a new tag used by a new policy would technically require re-validating existing policies, whereas with tags `{ ?: T }` we can leave the schema alone and avoid re-validation entirely.
 
-Schemas are also simpler with `{ T }` types, rather than a long list of optional attributes, and better communicate intent.
+Schemas are also simpler with `{ ?: T }` types, rather than a long list of optional attributes, and better communicate intent.
 
 ### Workaround: Tags as sets of key/value pairs
 

--- a/text/0068-entity-tags.md
+++ b/text/0068-entity-tags.md
@@ -1,0 +1,284 @@
+# Entity tags
+
+## Related issues and PRs
+
+- Reference Issues: [#305](https://github.com/cedar-policy/cedar/issues/305)
+- Supercedes [RFC 66](https://github.com/cedar-policy/rfcs/pull/66)
+- Implementation PR(s): (leave this empty)
+
+## Timeline
+
+- Start Date: 2024-05-29
+- Date Entered FCP:
+- Date Accepted:
+- Date Landed:
+
+## Summary
+
+This RFC proposes to extend the Cedar type system with the ability to attach _tags_ to entities. Entity tags are similar to records, where keys are like record attributes and values are like attribute values. But keys need not be enumerated in advance, as is required with record attributes, and all values must have the same type.
+
+The main body of this RFC proposes that tag keys must be _literals_ when used to look up a tag's value, just like record attributes, but Alternative A generalizes this proposal to allow keys to be dynamically computed. Alternative A thus adds expressive power but also implementation cost.
+
+### Basic example
+
+Here is a schema defining two entities, each of which contains entity tags.
+```
+entity User = {
+  jobLevel: Long,
+  authTags: Tags<Set<String>>,
+};
+entity Document = {
+  owner: User,
+  policyTags: Tags<Set<String>>, 
+};
+```
+The `User` and `Document` entities each have an attribute of type `Tags<Set<String>>`, identifying tags whose values are sets of strings. Here's a policy that conforms to this schema:
+```
+permit (
+  principal is User,
+  action == Action::"writeDoc",
+  resource is Document) 
+when {
+  document.owner == principal ||
+    (principal.jobLevel > 6 &&
+    resource.policyTags has "write" && 
+    principal.authTags has "write" && 
+    resource.policyTags["write"].containsAny(principal.authTags["write"]))
+};
+```
+This policy states that for a `User` to carry out the _writeDoc_ action on a `Document`, the user must own the document, or else the user's job level must be at least 6 and the document and the user must each have a `write` tag in their attached tags, where at least one of the user's write-tag's values must be present in the document's write-tag's values.
+
+## Detailed design
+
+Neither the Cedar evaluator/authorizer, the JSON format for entities, nor the JSON or natural syntax for policies needs to change to support entity tags. This is because tags are represented as records and support the same operations. Only the Cedar schema format, the validator, and the schema-based entity parser need to change to account for a new `Tags<T>` type.
+
+### Schema
+
+Tags have type `Tags<T>`, where `T` is the type of tag values. Only entity attributes can be given type `Tags<T>`, and `T` cannot directly mention another `Tags` type.
+
+We extend schemas as follows to support the new `Tags` type. Here's the natural syntax:
+```
+Entity           := 'entity' Idents ['in' EntOrTyps] [['='] EntityRecType] ';'
+EntityRecType    := '{' [EntityAttrDecls] '}'
+EntityAttrDecls  := Name ['?'] ':' [Type | TagsType] [',' | ',' EntityAttrDecls]
+TagsType         := 'Tags' '<' Type '>'
+Type             := PRIMTYPE | Path | SetType | RecType
+```
+In essence: We alter the definition of entity types to include attributes with type `Tags<T>`, where `T` is any non `Tags`-containing type. Not shown here are the productions for `RecType` and `AttrDecls`, which apply to records rather than entities. These productions are unchanged---normal records may not include attributes with `Tags<T>` types.
+
+The JSON syntax for schemas extends the `type` specifier to include `Tags`, for which there is a companion attribute `element`, which is itself a `type`. The JSON syntax parser only permits the `Tags` type to appear in entity attributes, and likewise restricts the `type` associated with `element` to not include `Tags`, itself. Here's our introductory example schema in this format:
+```
+"entityTypes": {
+    "User" : {
+        "shape" : {
+            "type" : "Record",
+            "attributes" : {
+                "jobLevel" : {
+                    "type" : "Long"
+                },
+                "authTags" : {
+                    "type" : "Tags",
+                    "element" : {
+                        "type" : "Set",
+                        "element": "String"
+                    }
+                }
+            }
+        }
+    },
+    "Document" : {
+        "shape" : {
+            "type" : "Record",
+            "attributes" : {
+                "owner" : {
+                    "type" : "Entity",
+                    "name" : "User"
+                },
+                "policyTags" : {
+                    "type" : "Tags",
+                    "element" : {
+                        "type" : "Set",
+                        "element": "String"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+### Policies, entities, and evaluation
+
+Tags support all of the same operations as records. Suppose that `E` is an expression of type `Tags<T>`. Then expression `E has F` will check whether `E` has tag key `F`, evaluating to `true` if so and `false` otherwise. Expression `E.F` or `E["F"]` will retrieve the value associated with key `F` if `F` is present, signaling an error if it is not.
+
+As a result, within the evaluator we can represent tags as records, so the evaluator code does not need to change. In particular, tags with keys `F1` ... `Fn` and associated values `V1` .. `Vn` are internally represented as records `{ F1: V1, ..., Fn: Vn }`. Similarly, tags are represented as records in the JSON entity format. For example, here is entity representing `User::"Alice"` which conforms to our example schema:
+```
+    {
+        "uid": { "type": "User", "id": "alice" },
+        "attrs": {
+            "jobLevel": 5,
+            "authTags": {
+                "write": ["blue", "red"],
+                "read": ["blue", "red", "green"]
+            }
+        },
+        "parents": []
+    }
+```
+Note that there is no way to represent a `Tags` _literal_. That is, you cannot write something like `{ write: ["blue", "red"]}` in a policy, like you might for a record literal. This is because tags are always attached to entities, and entities themselves have no literal syntax.
+
+### Validating policies
+
+We extend the way the policy validator handles optional record attributes in order to support entity tags.
+
+#### Capabilities
+
+While typechecking an expression involving records or entities with optional attributes, the validator tracks _capabilities_. These represent the attribute-accessing expressions that are sure to succeed. If `principal` has type `User` and `User` has an optional `Boolean` attribute `sudo`, then the expression `principal.sudo` only validates if `principal.sudo` is present in the _current capability set_. Capabilities are added to that set by a preceding expression of the form `principal has sudo`, e.g., as in `principal has sudo && principal.sudo`.
+
+Capability tracking must be generalized to support tags. In particular, an entity attribute of type `Tags<T>` should be treated as a record with optional attributes, and `has` checks on its keys should update the capability set. For our introductory example, consider the following the expression 
+```
+  resource.policyTags has "write" && // (1)
+  principal.authTags has "write" &&  // (2)
+  resource.policyTags["write"].containsAny(principal.authTags["write"]) // (3)
+```
+After the subexpression (1), `resource.policyTags.write` should be added to the current capability set. After subexpression (2), `principal.authTags.write` should be added to it. Finally, when validating subexpression (3), the expression `resource.policyTags["write"]` will be considered valid since `resource.policyTags.write` is in the current capability set and it will be given type `Set<String>`, as `resource.policyTags` has type `Tags<Set<String>>`. The expression `principal.authTags["write"]` is handled similarly. If either of the `has` subexpressions (1) or (2) were omitted, subexpression (3) would not validate due to the missing capability set entries.
+
+#### Permissive Validation: Subtyping
+
+For permissive validation, we adjust subtyping to allow `Tags` types to be treated co-variantly:
+```
+Tags<T> <: Tags<U>    iff T <: U
+```
+We might consider adding rules that permit subtyping between records and tags, but doing so introduces some complications with width subtyping. Indeed, we could also consider granting `Tags` more first-class stature when carrying out permissive validation. We reserve the right to extend the typing and subtyping rules in the future, if needed.
+
+### Validating and parsing entities
+
+The Cedar authorizer's `is_authorized` function can be asked to validate that entities in a request are consistent with a provided schema. Extending validation to work with tags is straightforward. The type rule is basically thus:
+```
+v1: T ... vn: T
+---------------------------------
+{ f1: v1, ..., fn: vn } : Tags<T>
+```
+In particular, when asked to determine if a record has type `Tags<T>`, we confirm that all values in the record have type `T`. By the nature of restrictions on schemas, the validator will only ever consider `Tags<T>` types associated with entity attributes.
+
+Similarly, schema-based parsing considers schemas when parsing in entities, and it can confirm when parsing that attributes labeled as `Record` in the JSON but defined as `Tags<T>` in the schema have the appropriate shape.
+
+## Drawbacks
+
+### Non-dynamic keys
+
+`Tags<T>` attributes require keys to be statically identified in policies, as literals. For example, you cannot write the following policy expression (using our example schema from above):
+```
+principal.authTags has context.key && 
+principal.authTags[context.key] == context.value
+```
+Supporting dynamic keys is more work, but doable. With them, `Tags<T>` tags would be strictly more powerful than existing tag encodings/workarounds. We sketch the needed implementation work in Alternative A, below, and a comparison to workarounds further below.
+
+### Second-class status
+
+Only entity attributes are permitted to have type `Tags<T>`, which eliminates the possibility of `Tags<T>` literals and tags directly containing other tags. 
+
+These restrictions are present for two reasons. First, second-class status ensures tags are efficiently _analyzable_. Allowing first-class `Tags` values would require supporting equality between `Tags` values. Supporting equality would require policy analysis to model tags as arrays imbued with the extensionality axioms, which are known to be expensive. Second, second-class status means that we cannot introduce `Tags` literals, which means we do not need to introduce new syntax for tags, which would be essentially the same as record literal syntax, leading to user confusion. Nor do we need to consider how we might treat record literals as equivalent to `Tags<T>` values.
+
+The use-cases that we are aware of do not suffer from these limitations. Typically, you want to attach tags to principals and resources. If you wanted tags to contain other tags, or you wanted to store tags in the `context` record, you can create specific entity types containing only those tags. For example:
+```
+entity User {
+    roles: Set<String>,
+    roleTags: Tags<StringTags>,
+};
+entity StringTags {
+    tags: Tags<String>
+};
+```
+In effect, the `User`'s `roleTags` is equivalent to `Tags<Tags<String>>`, but we have added a level of indirection by expressing the inner `Tags<String>` value as an entity with a `Tags<String>` attribute.
+
+### Implementation effort
+
+The implementation effort for adding tags is non-trivial, as it will require changing the Rust code, the Lean models and proofs, and the differential test generators. It will also affect any component that leverages the schema and validator algorithms, such as schema-based parsing, and the policy analyzer.
+
+That said, these changes are relatively straightforward:
+- The validator changes are a straightforward extension to the handling of records with optional attributes. The extension to subtyping for permissive validation is also simple.
+- Changes to entity validation and schema-based parsing are fairly localized: They must consider the new `Tags` type when validating/parsing JSON `Record`-labeled entities.
+- The policy analyzer can model `Tags<T>` attributes as uninterpreted functions because it never needs to consider equality between `Tags<T>` values. Equality between entities is _nominal_ -- we just consider the entity UID, not the contents of an entity's mapped-to attribute record (the only place that tags can exist).
+- There are _no_ changes to the evaluator or partial evaluator: From an evaluation perspective, `Tags<T>` attributes are just attributes containing records whose attributes all have values of type `T`.
+
+## Alternatives
+
+### Alternative A: Tags with dynamic keys
+
+Supporting dynamic keys (see "Drawbacks: Non-dynamic keys" above), requires a few extensions to the main proposal: to the policy grammar, evaluator (and partial evaluator), validator, and analysis.
+
+#### Policy grammar and evaluator
+
+We change the [grammar for `has`](https://docs.cedarpolicy.com/policies/syntax-grammar.html#relation) so that the given attribute can be a [`Member`](https://docs.cedarpolicy.com/policies/syntax-grammar.html#member), rather than an `IDENT`:
+```
+Relation ::= ... | Add 'has' (Member | STR)
+```
+Here, if `Member` is just an identifier like `foo` then it is interpreted as a key name. Otherwise it is treated as an expression that should be evaluated to a string, which is the name of the key.
+
+For completeness here is the current `Member` grammar:
+```
+Member ::= Primary {Access}
+Access ::= '.' IDENT ['(' [ExprList] ')'] | '[' STR ']'
+Primary ::= LITERAL 
+           | VAR 
+           | Entity 
+           | ExtFun '(' [ExprList] ')' 
+           | '(' Expr ')' 
+           | '[' [ExprList] ']' 
+           | '{' [RecInits] '}'
+```
+
+We also change [attribute access](https://docs.cedarpolicy.com/policies/syntax-grammar.html#access) to allow `Member` to appear within brackets. The semantics is that we evaluate `Member` to a string, and then use that string to access the attribute.
+```
+Access ::= '.' IDENT ['(' [ExprList] ')'] | '[' STR ']' | '[' Member ']'
+```
+It may be that `Member` is a bit too expressive. If so, we may consider making key-computing expressions simpler, e.g., `foo.bar.baz`, and not `User::"foo".bar.baz` or `{ foo: "bar" }.foo`.
+
+We can allow this extended syntax and evaluation semantics to apply to normal record and entity attributes as well. The validator will prevent it, however, so it will only be possible for non-validated policies.
+
+#### Validator
+
+The validator must change to further extend capability tracking from what we've described above to include dynamically contructed attribute names. This should be straightforward. When the validator sees something like `principal.tags has resource.name` then this would generate the capability `principal.tags[resource.name]` that would allow a follow-on expression `principal.tags[resource.name]` to validate. 
+
+In addition, it's now possible that an attribute-constructing expression could access a bogus attribute, so those expressions must be validated as well. E.g., when validating `principal.tags has resource.name` or `principal.tags[resource.name]`, the validator must confirm that `resource` indeed has a `name` attribute.
+
+Because expressions like `principal has context.name` are now grammatically legal, the validator must be updated to consider them fully. In partcular, the validator should only allow `F` to be an expression when writing `E has F` or `E[F]` if `E` has type `Tags<T>`---it will not be allowed when `E` has a normal record or entity type.
+
+#### Analysis
+
+The policy analyzer's logical encoding must be generalized to account for keys being specified as expressions rather than as literals. Because we are encoding tags as uninterpreted functions from strings (the key) to values, this presents no problem: it doesn't matter whether the key is a literal string or an expression that evaluates (is equivalent) to a string. That said, counterexample generation could be a little more involved.
+
+#### Summary
+
+There is a tradeoff here. Alternative A is more work to implement than the RFC as given, but not significantly more. And it carries a significant benefit: It enables this notion of tags to be strictly more expressive than both of the workarounds given below, which are modeling tags as optional attributes, and modeling tags as sets of key-value pairs. Anything you can do with either of those workarounds you can do with Alternative A. As a result, policy writers will be encouraged to always use `Tags` directly, which will be easier to manage for policy readers.
+
+### Alternative B: Open records
+
+Previously, [RFC 66](https://github.com/cedar-policy/rfcs/pull/66) proposed _open records_ as a generalization of records suitable for encoding tags. Open records are first-class values, however, and so they add far more complication to the implementation effort. See that RFC for further discussion.
+
+### Alternative C: Maps
+
+Another prior RFC, [RFC 27](https://github.com/cedar-policy/rfcs/pull/27), proposed to create `map<T>` types as alternative types for records whose attributes all have the same type `T`, and whose attributes can be dynamically constructed (like dynamic keys for Alternative A, above). That RFC's `map<T>` type is quite similar to this RFC's `tags<T>` type except that maps are not second-class, and support dynamic keys. Supporting maps would lead to even greater implementation challenges than open records, per discussion on both of those prior RFCs.
+
+### Workaround: Records with optional attributes
+
+We could avoid adding tags entirely and work around their absence.
+
+A direct workaround is to implement tags as a record type that enumerates every legal tag as an optional attribute. Then, every time you create a policy that mentions a tag key as a literal, the validator will complain if that key is not in the schema. So, add the key to the schema, and the new policy will validate along with the old ones.
+
+The drawback of this approach is that hanging the schema on the fly to extend the list of valid keys could be expensive. If policies are being constructed on the fly, e.g., by a service's users, a schema update to support a new tag used by a new policy would technically require re-validating existing policies, whereas with open `Tags<T>` values we can leave the schema alone and avoid re-validation entirely.
+
+Schemas are also simpler with `Tags<T>` types, rather than a long list of optional attributes, and better communicate intent.
+
+### Workaround: Tags as sets of key/value pairs
+
+Another way to implement tags is as sets of key-value pairs. For example, `principal.tags` could have type `Set<{ key:String, value:String }>` and a tag check would involve an expression like `principal.tags.contains({ key: "priority", value: "green" })`.
+
+This approach has the benefit that keys can be dynamic. E.g., you can write
+```
+principal.tags.contains(context.tagvalue)
+```
+where `context.tagvalue` can be dynamically determined. However, with this encoding of tags you cannot write expressions such as `resource.tags["project"] == principal.tags["project"]`
+or 
+`resource.tags["projects"].contains(principal.tags["project"])`. We find this to be a strong limitation, as customers often want to exprss policies that relate the tags of principals to those of resources. Note that [RFC 21](https://github.com/cedar-policy/rfcs/pull/21) would lift this limitation through the introduction of the `any?` and `all?` operators, but it was rejected due to problems with logically encoding these operators during policy analysis.

--- a/text/0068-entity-tags.md
+++ b/text/0068-entity-tags.md
@@ -170,9 +170,9 @@ Similarly, schema-based parsing considers schemas when parsing in entities, and 
 
 ### Permissive Validation
 
-Permissive validation supports subtyping, which we extend so as to allow tags types to be treated co-variantly:
+Permissive validation supports subtyping, which we extend so as to allow tag types to be treated co-variantly:
 ```
-{ ?: T } <: { U }    iff T <: U
+{ ?: T } <: { ?: U }    iff T <: U
 ```
 We might consider adding rules that permit subtyping between records and tags, but doing so introduces some complications with width subtyping. We could choose to grant tags first-class status under permissive validation. For example, we could allow tags values to appear anywhere, e.g., in `Set`s or records, and we could allow equality between tags values. We choose not to do these things for now.
 

--- a/text/0075-entity-slice-validation.md
+++ b/text/0075-entity-slice-validation.md
@@ -1,0 +1,430 @@
+# Entity Slice Validation
+
+## Related issues and PRs
+
+* Reference Issues:
+* Implementation PR(s):
+
+## Timeline
+
+* Started: 2024-07-09
+
+## Summary
+
+This RFC introduces "Entity Slicing Validation" (ESV), which consists of
+
+1. An additional validation check, and
+2. A generic entity slicing algorithm
+
+The two are connected by the concept of a "level," which defines the depth from root variables (like `principal` and `resource`) at which entity dereferencing operations may safely take place in policies. The validation check ensures that policies never dereference beyond the given level. The slicing algorithm determines what entities are needed to safely decide an authorization request when evaluating policies valid at a given level.
+
+## Basic example
+
+Consider the following [policies](https://github.com/cedar-policy/cedar-examples/blob/release/3.2.x/tinytodo/policies.cedar), taken from the [TinyTodo example application:](https://github.com/cedar-policy/cedar-examples/tree/release/3.2.x/tinytodo)
+
+```
+// Policy 1: A User can perform any action on a List they own
+permit (
+  principal,
+  action,
+  resource is List
+)
+when { resource.owner == principal };
+
+// Policy 2: A User can see a List if they are either a reader or editor
+permit (
+    principal,
+    action == Action::"GetList",
+    resource
+)
+when { principal in resource.readers || principal in resource.editors };
+
+// Policy 4: Admins can perform any action on any resource
+permit (
+  principal in Team::"Admin",
+  action,
+  resource
+);
+```
+
+We suppose (per the [schema](https://github.com/cedar-policy/cedar-examples/blob/release/3.2.x/tinytodo/tinytodo.cedarschema), not shown) that `principal` always has entity type `User`, and `resource` always has entity type `List`. These policies are valid at level 1, meaning that variables `principal`, `action`, `resource` and `context` are only *directly* dereferenced, i.e., any entities they reference are not themselves dereferenced.
+
+For example, in policy 1, the expression `resource.owner == principal` directly dereferences `resource` by accessing the contents of its `owner` attribute. In policy 2, expression `principal in resource.readers` directly dereferences `resource` to retrieve the contents of its `readers` attribute, and also directly dereferences `principal` to retrieve its ancestors, to see whether one might be equal to the contents of `resource.readers`. Policy 4 also directly dereferences `principal` to access its ancestors, to see if one is `Team::"admin"`.
+
+Because these policies are valid at level 1, applications submitting authorization requests only need to provide entity data for entities provided as variables, and nothing else. For example, say we want to evaluate the request (`User::"Aaron"`, `Action::"GetList"`, `List::"Objectives"`, `{}`). Then we would only need to provide entity data (direct attributes and ancestors) for `User::"Aaron"`, `Action::"GetList"`, and `List::"Objectives"`. There is no need to provide data for entities referenced from these entities. For example, suppose the `readers` attribute of `List::"Objectives"` is `Team::"interns"`; there is no need to provide data for `Team::"interns"` because we know it will never, itself, be dereferenced when evaluating these policies. There is also no need to provide entity data for other entities directly mentioned in policies, e.g., `Team::"Admin"`.
+
+Now suppose we wanted to extend our TinyTodo policies with the following:
+
+```
+// Policy 6: No access if not high rank and at location DEF, 
+// or at resource's owner's location
+forbid(
+    principal,
+    action,
+    resource is List
+) unless {
+   principal.joblevel > 6 && principal.location like "DEF*" ||
+   principal.location == resource.owner.location
+};
+```
+
+This policy does *not* validate at level 1. That is because the expression `resource.owner.location` is only valid at level 2: It requires dereferencing `resource` to retrieve the entity in the `owner` attribute, and then requires dereferencing that entity to obtain the contents of its `location` attribute. As a result, if we only provided the `principal` and `resource` entity data, as described above, evaluating policy 6 could produce an evaluation error since data may not be provided for `resource.owner`.
+
+All of the Cedar example policy sets validate with level-based validation, either at level 1 or 2; see the Appendix for details.
+
+## Motivation
+
+Currently, Cedar provides no support for slicing. Users are required to either be inefficient and produce their entire entity store as a slice, or derive their own ad-hoc slicing algorithm. We'd like to provide an out-of-the-box solution that addresses many user's needs. Entity slicing in general is a problem very tied to the specifics of application/deployment. It's likely impossible to have a fully general solution. This RFC is attempting to provide a solution for entity slicing that works for the 80% case, while acknowledging that it won't work for everyone. 
+
+Additionally, there are some application scenarios where the actors writing the policies and the people performing slicing are not the same people, and thus the slicers need to impose some kind of restrictions on policy authors.
+
+## Detailed design
+
+### Entity dereferences
+
+An "Entity Dereference" is any operation that requires directly accessing an entity’s data. The following is an exhaustive list of entity dereferencing operations
+
+1. `e1 in e2` dereferences `e1` (but not `e2`)
+2. `e1.foo` dereferences `e1` iff `e1` is an entity
+3. `e1 has foo` dereferences `e1` iff `e1` is an entity
+
+Note that testing equality *is not* a dereferencing operation. Therefore expressions like `e1 == e2`, `e1.contains(e2)` and `e3 in e2` do not dereference `e1` or `e2`.
+
+Also note that by “dereference” above, we are only referring to the given operation, not about any operations that might be executed to evaluate subexpressions. For example, while `e1 in e2` only dereferences `e1` (per rule 1 above), if `e2` is `principal.foo`, then of course evaluating `e2` dereferences `principal` (per rule 2 above).
+
+### Entity roots
+
+The variables `principal`, `action`, and `resource` are *entity roots*. (Entity literals are *not* entity roots, and operations on such literals are limited, as described below.) They directly name entities from a request that could be dereferenced in a policy. A `context` is not an entity root directly; rather, any attributes it (transitively) contains that have entity type are considered roots. For example, consider the following schema:
+
+```
+entity User {
+    manager: User,
+    age: Long,
+};
+action getDetails appliesTo {
+    principal: User,
+    resource: User,
+    context: {
+        admin: User,
+        building: { location: Long, ITDeptHead: User },
+        foo: { inner: User },
+        bar: { inner: User }
+    }
+};
+```
+
+Here, `principal`, `action`, and `resource` are entity roots (as usual), as are:
+
+* `context.admin` 
+* `context.building.ITDeptHead` 
+* `context.foo.inner` , and 
+* `context.bar.inner`
+
+Note that `context`,  `context.building`, and  `context.building.location` are *not* entity roots because they do not have entity type. Moreover, `context.admin.manager` is not an entity root because `manager` is not an attribute of `context` itself.
+
+### Dereference levels
+
+During validation, we extend entity types with a *level*, which is either `∞` or a natural number. We call these *leveled entity types*. The level expresses how many entity dereferences are permitted starting from an expression having that type. Levels on types are only used internally; policy/schema writers never see them. When the level is `∞`, validation is unchanged from the status quo.
+
+### Specifying the level
+
+The maximum level that policies may validate at is specified in the schema. The benefit of this is that policy writers can see the expected form of policies in one place. For example, we could extend our schema above as follows:
+
+```
+level = 1;
+entity User {
+    manager: User,
+    age: Long,
+};
+action getDetails appliesTo { ... }
+```
+
+Policy writers know, by seeing `level = 1`, that they can write `principal.manager` in policies, but not `principal.manager.manager`.
+
+### Validation algorithm
+
+Validation works essentially as today (see our [OOPSLA’24 paper](https://dl.acm.org/doi/pdf/10.1145/3649835), page 10), but using leveled types. To validate a policy c at level N, we use a request environment which maps `principal`, `resource`, and `context` to leveled types with level N. For example, for the schema given above, to validate at level 2 our request environment would map `principal` to `User`(2), `resource` to `User`(2), and `context` to the type given in the schema annotated with 2, i.e., `{ admin: User(2), building: { location: Long, ITDeptHead: User(2) },... }`.
+
+The rules for expression `e1 in e2` (line (3) in Fig. 7)(a) in the paper) are extended to require that the entity type of `e1` is `E1(n)` where `n > 0`. This requirement indicates that `e1` must be an entity from which you can dereference at least one level (to access its ancestors).
+
+The rules for expression `e has f` and `e.f` (line (6) in Fig. 7(a) in the paper) are extended so that if `e` has entity type, then its type must be `E(n)` where `n > 0`. The rule for `e.f` is additionally extended so that if `e.f` has entity type `F` (per the schema), then the the final type is leveled as one less than `n`; e.g., if `e` has level `n`, then final expression has type F`(n-1)`. (Rules for `e has f` and `e.f` are unchanged when `e` has record type.)
+
+The rule for entity literals (not shown in the paper) always ascribes them level 0 unless we are validating at level  `∞`. For example, the type of expression `User::"Alice"` is `User(0)`. This is because we do not permit dereferencing literals in policies when using leveled validation. (See the Alternatives below for a relaxation of this restriction.)
+
+We extend the subtyping judgment (Fig 7(b) in the paper) with the following rule: `E(n) <: E(n-1)`. That is, it is always safe to treat a leveled entity type at level `n` as if it had fewer levels. This rule is important when multiple expressions are required to have the same level. For example:
+
+```
+if (principal.age < 25) then
+  principal.manager
+else
+  principal
+```
+
+Suppose we are validating at level 2, then this expression will have type `User(1)`, where we use subtyping to give expression `principal` (in the else branch) type `User(1)` rather than `User(2)`. Similarly, if we were defining a set of entities, all of them must be given the same level. For example, we could give `[ principal.manager, principal ]` the type `Set<User(1)>`. Note that for records, individual attributes may have entities with different levels. E.g., `{ a: principal, b: principal.manager }` would have type `{ a: User(2), b: User(1) }`.
+
+### Slicing 
+
+Once a schema has been validated against a non- infinite level, we can use the following procedure at runtime to compute the entity slice: 
+
+```
+/// Takes:
+/// request : The request object
+/// level : The level the schema was validated at 
+/// get-entity : A function for looking up entity data given an EUID 
+function slice(request, level, get-entity) { 
+    // This will be our entity slice
+   let mut es : Map<EUID, EntityData> = {};
+
+   let mut worklist : Set<EUID> = {principal, action, resource, all root euids in context};
+   for euid in worklist {
+     es.insert(euid, get-entity(euid));
+   }
+   
+   let current-level = 0;
+   
+   while current-level <= level || worklist.empty? {
+        // `t` will become our new worklist
+        let t : Set<EUID> = {};
+        // Clear our worklist
+        for euid in worklist {
+            if !es.contains(euid) {
+                es.insert(euid, get-entity(euid));
+            }
+            ; Set of all euids mentioned in this entities data
+            let new-euids = filter(not-in-es?, all-euids(es.get(euid));
+            t = t.union(new-euids);
+        }
+        // set t to be the new worklist
+        s = t;
+        // increment level
+        level = level + 1;
+   }
+
+    return es;
+}
+
+```
+
+### Soundness
+
+Leveled types permit us to generalize the soundness statement we use today. Currently, soundness assumes that expressions like `principal.manager` will never error, i.e., that the proper entity information is available. Now we assume dereferences are only available up to a certain level. In particular, we define a well-formedness judgment μ⊢v:τwhere μ is an entity store, v is a value, and τ is a possibly leveled type. This judgment is standard for values having non-entity type, e.g.,
+
+```
+mu |- i : Long
+
+mu |- s : String
+
+mu |- v1 : T1 ... mu |- vn : Tn 
+-------------------------------------------------------
+mu |- { f1: v1, ..., fn: vn } : { f1: T1, ..., fn: Tn }
+```
+
+There are two rules for entity literals of type `E::s`. The first says level `0` is always allowed. The second says a literal can have a level `n` only if `n` dereferences are possible starting from `E::s`:
+
+```
+mu |- E::s : E(0)
+
+mu(E::s) = (v,h) where v = { f1: v1, ..., fn: vn } and h is an ancestor set
+mu |- v1 : T1 ... mu |- vn : Tn
+where level(T1) >= n-1
+------------------------------------------------------------------------------------
+mu |- E::s : E(n) where n > 0
+```
+
+The auxiliary function `level(T)` identifies the lower-bound of the level of type `T`. It’s defined as follows:
+
+* `level(E(n))` = `n`
+* `level({ f1: T1, ..., fn: Tn })`  = `m` where `m` = `min(level(T1),...,level(Tn))`
+* `level(Long)` = `level(String)` = `level(Boolean)` = `level(Set(T))` = (etc.) = ∞ for all other types
+
+Thus the soundness statement says that 
+
+1. If policy set `p` is validated against a schema `s` with level `l`, where  `l < ∞` .
+2. If entity store μ is validated against schema `s` 
+3. If request σ is validated against schema `s` 
+4. If μ ⊢ σ(principal): E(l) where E is the expected type of the principal for this particular action, and  similarly check the proper leveling of action, request, and context.
+    1. We prove separately that `slice` and σ produces a store μ that satisfies this property
+5. Then: 
+    1. `isAuthorized(sigma, p, mu)` is either a successful result value or an integer overflow error
+        1. All errors except integer overflow + missing entity are prevented by the current validator 
+        2. missing entity errors are prevented by the new validator + slicer 
+
+We extend the proof of soundness to leverage premise #4 above: This justifies giving `principal` a type with level l in the initial request context, and it justifies the extensions to the rules that perform dereferencing, as they decrease the leveled result by 1, just as the μ⊢v:τ rule does, which we are given.
+
+## Drawbacks
+
+Level-based slicing is coarse-grained: *all* attributes up to the required level, and *all* ancestors, for each required entity must be included in the slice. Much of this information may be unnecessary, though, depending on the particulars of the request. For example, for the TinyTodo policies in our detailed example, if the action in the request was `Action::"CreateList"`, then only policies 1 and 4 can be satisfied. For these policies, no ancestor data for `principal` and `resource` is needed, and only the contents of `resource.owner`, and not (say) `resource.readers` and `resource.editors`, is required. For some applications, the cost to retrieve all of an entity’s data and then pass it to the Cedar authorizer could be nontrivial, so a finer-grained approach may be preferred. Some ideas are sketched under alternatives.
+
+Implementing levels is a non-trivial effort: We must update the Rust code for the validator of policies and entities, and the Lean code and proofs. We also must provide code to perform level-based slicing.
+
+## Alternatives
+
+### Alternative: Level as a validation parameter, not in the schema
+
+This RFC has suggested that the level should be specified in the schema. Alternatively, we could specify the level as a parameter to the validator itself, leaving schemas unchanged. The benefit of doing so is that entity slicing becomes an orthogonal concern: The schema specifies the structure of data, but nothing about what data is required/allowed for a request. The drawback is that policy writers cannot look in one place to know the limits on the policies they can write.  
+
+### Alternative: Per-entity levels, rather than a global level
+
+We might refine in-schema `level` to not apply to all entities, but rather to particular entity types. For example, for `User` entities (bound to `principal`) we might specify level 2 but for any other entity type we specify `level` as 0, as per the following schema:
+
+```
+@level(2)
+entity Issue = {
+  repo: Repository
+};
+@level(0)
+entity Repository = {
+  owner: User,
+  readers: Set<User>,
+};
+@level(0)
+entity User = {
+  manager: User
+};
+action ReadIssue appliesTo { principal: User, resource: Issue };
+```
+
+Per-entity levels allows you to reduce the entities you provide in the slice — given a request, you get the types of the principal and resource entities, look up what their levels are from the schema, and then provide data up to that level for each. Validation for per-entity levels is also a straightforward generalization of the algorithm sketched above.
+
+Note that per-entity levels adds some complication to understandability, in particular for nested attributes. The question is whether the performance benefits are worth it. Suppose I have a policy
+
+```
+permit(principal, action, resource) when {
+  resource.repo.owner.manager == principal
+};
+```
+
+This is allowed because `Issue` is labeled with level 2. That means that we are allowed to write `resource.repo.owner.manager` (two levels of dereference beyond the first, allowed one by level 0). But this is a little confusing because we wrote `@level(0)` on `Repository`, and yet we are accessing one of its attributes. The reason that’s Ok is that `Repository` never actually is bound to `principal` or `resource`, so the level is irrelevant.
+
+### Alternative: Full support for entity literals
+
+Entity literals cannot be dereferenced. That means that, *at all levels*, they can only appear in `==` expressions or on the RHS of `in`. This captures use-cases that we know about. However, if you wanted to use them on the LHS of `in` or access their attributes, one approach to doing this would be to extend [enumerated entity types](https://github.com/cedar-policy/rfcs/blob/main/text/0053-enum-entities.md) to normal entity type definitions. For example, 
+
+```
+entity User in [Team] enum { "default" @level } = {
+  manager: User,
+  organization: Org
+}; 
+```
+
+This would say that there is a `User` entity whose ID is `default` which should always be present in the entity slice, e.g., along with other entities for the principal, resource, etc. That presence is at the level specified globally, e.g., if `level`was 1, then just the `User::"default"` and its direct attributes would be included, but not the entities those attributes point to.
+
+### Alternatives: Extensions to reduce ancestor requirements
+
+One drawback of level is that it gets *all* of an entity’s ancestors when it is included in a slice. This could be very expensive in the case that the entity has many such ancestors. For example, in TinyTodo, each `User` has `Team`-typed ancestors that correspond to the `viewers` or `editors` of the `List` entities which they can access. This could be 1000s of lists, which are expensive to acquire and to include in the request (especially if calling AVP). Worse, this work is apparently wasted because the policies can only ever look at *some* of these ancestors, notably those reachable from the `editors` or `viewers` of the resource *also provided in the request*. 
+
+Instead of passing in a principal in a request with all of its ancestors, we could just as well pass in only those that are possibly referenced by policy operations. For TinyTodo, it would be those equal to `resource.viewers` or `resource.editors` (if they match). Since this invariant is not something the application necessarily knows for certain (it might be true of policies today, but those policies could change in the future), we want a way to **reduce the provided ancestor data while being robust to how policy changes in the future**. Here are three possible approaches to addressing this issue.
+
+#### Alternative 1: Leverage partial evaluation
+
+We can use partial evaluation to solve this problem: Specify a concrete request with all of the needed attribute data, after entity selection, but **set the ancestor data as **** *unknown***. Partially evaluating such a request will result in results that have incomplete entity checks. These checks can then be handled by the calling application. This might be a nice feature we can package up and give to customers as a client-side library.
+
+A drawback of this approach is that it could slow down evaluation times. This is because the entity hierarchy is used to perform policy slicing. In the worst case, you’d have to consider all possible policies. It might be possible to provide at least *some*of the hierarchy with the request to reduce the set of policies that are partially evaluated. 
+
+#### Alternative 2: Ancestor allow-lists
+
+When validating static policies, it’s possible to see which ancestors are potentially needed. Could we do something similar to `level` for policy validation, but for ancestors instead?
+
+For TinyTodo policies above, we see the following expressions in policies:
+
+* `principal in resource.viewers`
+* `principal in resource.editors`
+* `principal in Team::"admin"`
+
+For the other examples, the situation is similar. We also see multi-level access, e.g., with GitHub policies `principal in resource.repo.readers`, and we see recursive access through sets, e.g., for Hotel Chains we see `resource in principal.viewPermissions.hotelReservations` where `hotelReservations` is a set containing entities, rather than being a single entity.
+
+_Approach_: Add an annotation `@ancestors` to the `in` declarations around entities. When I write `entity User in [Team]`, add an annotation that enumerates the `Team`-typed expressions that can be on the RHS of `in` in policies. Here’s an example of the annotated TinyTodo schema:
+
+```
+@ancestors(resource.viewers,resource.editors,Team::"admin",Team::"interns")
+entity User in [Team, Application] = {
+  "joblevel": Long,
+  "location": String,
+};
+@ancestors()
+entity Team in [Team, Application];
+@ancestors()
+entity List in [Application] = {
+  "editors": Team,
+  "name": String,
+  "owner": User,
+  "readers": Team,
+  "tasks": Tasks,
+};
+@ancestors()
+entity Application;
+...
+```
+
+Notice that we annotate `List`, `Team`, or `Application` with `()` since entities of these types never appear on the LHS of `in`. An entity type with no annotation at all is assumed to require every potential ancestor.
+
+_Validation_: The validator will check for syntactic equality against the expressions in the annotation. In particular, when it sees an expression `E in F` in a policy, if `E` has an entity type that is annotated with the set of expressions `S` in the schema, then the validator will check that `F` ∈ `S`, using syntactic equality. With the above schema, all current TinyTodo policies would validate, while the following would not
+
+```
+// Fails because a Team-typed entity is on the LHS of `in`,
+//   but entity Team has no legal RHS expressions per the schema
+permit(principal,action == Action::"GetList",resource)
+when { resource.editors in Team::"admin" };
+
+// Fails because Team::"temp" is not a legal RHS expression for User
+permit(principal in Team::"temp",action,resource);
+```
+
+_Entity selection_: When collecting ancestors with `getentity` [during entity selection](https://quip-amazon.com/oXOuAij6Bse8/Validating-Entity-Selection#temp:C:aLCfd096a6e6e5849aaadec7cc6f), the application only gets ancestors per the expressions in the annotation. To do that, it would evaluate these expressions for the current request, and provide the ancestors present in the result, if present. For example, suppose our TinyTodo request was
+
+```
+principal = User::"Alice"
+action    = Action::"GetList"
+resource  = List::"123"
+context   = {}
+```
+
+Since TinyTodo policies are `level` 2, we would provide entity data for both `User::"Alice"` and `List::"123"`. Suppose that the latter’s data is
+
+```
+{ id = "123", 
+  owner = User::"Bob",
+  viewers = Team::"123viewers",
+  editors = Team::"123editors"
+}
+```
+
+The `principal` has type `User`, which is annotated in the schema with the following expressions, shown with what they evaluate to:
+
+* `resource.viewers` evaluates to `List::"123".viewers` which evaluates to `Team::"123viewers"`
+* `resource.editors` evaluates to `List::"123".editors` which evaluates to `Team::"123editors"`
+* `Team::"admin"` (itself)
+* `Team::"interns"` (itself)
+
+Thus the application knows we can determine in advance whether `User::"Alice"` (the `principal`) has any of these four ancestors, and include them as such with `User::"Alice"`’s entity data, if so. No other ancestor data needs to be provided.
+
+Note: The above algorithm i not very helpful for templates containing expressions `in ?resource` or `in ?principal` ( (templates with only `== ?principal` and `== ?resource` in them are fine, since they don’t check the ancestors). For these, you are basically forced to not annotate the entity type because `?resource` and `?principal` are not legal expressions. This makes sense inasmuch as a template with constraint `principal in ?principal` tells us nothing about possible values to which `?principal` could be linked — the values could include potentially any entity, so in the worst case we’d need to include all possible ancestors. It may be that you could use further contextual data (like the action) to narrow the ones you provide.
+
+Note: Interestingly, no policy-set example ever has an expression other than `principal` or `resource` on the LHS of `in`. The scheme above is not leveraging this fact.
+
+Note: This approach composes nicely with the per-entity `@level` approach sketched above.
+
+### Alternative: Reduce attribute requirements
+
+The per-entity level approach is one way to reduce attribute requirements, but only across levels — for a particular entity you still must provide *all* of its attributes if you are providing its data. We might like to provide only *some* attributes, similar to the alternative that requires only some, not all, ancestors.
+
+As discussed earlier, partial evaluation can be used to help here. There could also be some sort of allow-list for attributes. Probably it would make sense to associate allow-lists with actions.
+
+## Appendix: Accepted policy sets
+
+All existing policies in published example Cedar applications can be validated using levels. In particular, the following policy sets validate at level 1:
+
+* Tags and roles: https://github.com/cedar-policy/cedar-examples/tree/main/cedar-example-use-cases/tags_n_roles
+* Sales orgs: https://github.com/cedar-policy/cedar-examples/tree/main/cedar-example-use-cases/sales_orgs
+* Hotel chains: https://github.com/cedar-policy/cedar-examples/tree/main/cedar-example-use-cases/hotel_chains
+
+And the following validate at level 2:
+
+* TinyTodo: https://github.com/cedar-policy/cedar-examples/blob/main/tinytodo/policies.cedar and also https://github.com/cedar-policy/cedar-examples/blob/main/tinytodo/policies-templates.cedar
+    * Policy 6 includes expression `resource.owner.location`
+* Tax Preparer: https://github.com/cedar-policy/cedar-examples/blob/main/cedar-example-use-cases/tax_preprarer/policies.cedar
+    * The access rule involves checking something to the effect of `principal.assigned_orgs.contains(resource.owner.organization)`. 
+* Document cloud: https://github.com/cedar-policy/cedar-examples/blob/main/cedar-example-use-cases/document_cloud/policies.cedar
+    * This has policy expression `(resource.owner.blocked.contains(principal) || principal.blocked.contains(resource.owner))`. (It would not make sense to duplicated the `blocked` 
+* GitHub: https://github.com/cedar-policy/cedar-examples/blob/main/cedar-example-use-cases/github_example/policies.cedar
+    * Expressions like `principal in resource.repo.readers` are common: A resource like an issue or pull request inherits the permissions of the repository it is a part of, so the rules chase a pointer to that repository.


### PR DESCRIPTION
Extending validation to support level-based entity slicing.

[Rendered](https://github.com/cedar-policy/rfcs/blob/entity-slice-validation/text/0075-entity-slice-validation.md)
