### PR TITLE
Update RFC-53 to constrain enum parents to also be enums.

### DIFF
--- a/text/0053-enum-entities.md
+++ b/text/0053-enum-entities.md
@@ -23,7 +23,7 @@ entity Task {
 action UpdateTask
     appliesTo { principal: [User], resource: [Task] };
 ```
-These data definitions could be used in policies such as 
+These data definitions could be used in policies such as
 ```
 permit(
     principal,
@@ -123,7 +123,7 @@ when {
     resource.status != Color.Red
 };
 ```
-This syntax is similar to what's provided for Java `enum`s. 
+This syntax is similar to what's provided for Java `enum`s.
 
 The benefit of this approach is that it may feel a little more natural than representing a concept, like a color, as a set of legal entity values. It would also be easy to encode this approach in a policy analysis.
 
@@ -145,13 +145,13 @@ action GetLists
                 resource: [Application]};
 ```
 This differs from some earlier examples in the following ways:
-1. Enumerated entities can have parents in the entity hierarchy, and can be parents of other enumerated entity values; both cases are shown in the definition of `RequestEntity`
+1. Enumerated entities can have parents that are enumerated entity values, and can be parents of other enumerated entity values; both cases are shown in the definition of `RequestEntity`
 2. Enumerated entities can appear as _singleton types_, e.g., as `RequestEntity::"Principal"` in the definition of action `GetLists`.
 
 Both of these extensions are similar to what's available for `Action`s right now, but generalized to arbitrary entity types. You could also imagine enumerated entity types having attributes, as has been anticipated for `Action`s.
 
 One drawback of this Alternative is that it creates added complication for both the validator (e.g., to handle singleton types) and the analyzer (e.g., to deal with the more general hierarchy constraints).
 
-Another drawback is that it adds complication to the entity store: Once you add hierarchy constraints and attributes, you need to create actual entities to include with policy requests (or extract them from the schema at request-time). The RFC as proposed does not require that.
+Another drawback is that it adds complication to the entity store: Once you add hierarchy constraints and attributes, you need to create actual entities to include with policy requests, by extracting them from the schema at request-time. The RFC as proposed does not require that.
 
 The good news is that this Alternative is a strict generalization of the RFC as proposed, which means if we agree to the current proposal we can later upgrade to some or all of this Alternative without incurring a breaking change.


### PR DESCRIPTION
This PR updates the Alternative C of RFC-53 to clarify that the parents of an enumerated entity value must also be an enumerated entity value.  This constraint is already enforced for actions, which are a special kind of enumerated entities.  We need to enforce it across the board for efficient analysis.

<!--
The below link will link to the rendered Markdown for your RFC, even before it is merged. You need to adjust it based on your RFC's filename and which fork and branch your PR is from.

* USERNAME: GitHub account or org where your fork of `rfcs` lives. Internal users using a feature branch of `cedar-policy` can just put `cedar-policy` here.

* REPONAME: Probably `rfcs` unless your fork has a different name

* BRANCHNAME: Name of the branch your PR is based on

* FILENAME.md: Filename of your RFC's markdown

Examples:

https://github.com/cedar-policy/rfcs/blob/placeholders-in-conditions/text/0003-placeholders-in-conditions.md

https://github.com/myusername/rfcs/blob/awesome-rfc-idea/text/0001-awesome-rfc-idea.md

-->

<!-- FIXME -->
[Rendered](https://github.com/cedar-policy/rfcs/blob/emina/enum-entities-parents/text/0053-enum-entities.md)
