### PR TITLE
fix proposed JSON syntax in RFC 68

### DIFF
--- a/text/0068-entity-tags.md
+++ b/text/0068-entity-tags.md
@@ -82,7 +82,7 @@ The JSON syntax for schemas specifies EA-maps as records with a `default` elemen
                     "type" : "Record",
                     "default": {
                         "type" : "Set",
-                        "element": "String"
+                        "element": { "type": "String" }
                     }
                 }
             }
@@ -100,7 +100,7 @@ The JSON syntax for schemas specifies EA-maps as records with a `default` elemen
                     "type" : "Record",
                     "default": {
                         "type" : "Set",
-                        "element": "String"
+                        "element": { "type": "String" }
                     }
                 }
             }


### PR DESCRIPTION
RFC 68's proposed JSON syntax contains syntactically incorrect declarations of `Set` types. This PR fixes that, as RFC 68 did not intend to propose new JSON syntax for declaring `Set` types.
