### PR TITLE
`datetime` extension: Adjust `duration` to account for zero-amount quantities

### DIFF
--- a/text/0080-datetime-extension.md
+++ b/text/0080-datetime-extension.md
@@ -169,7 +169,7 @@ The `datetime` type is internally represented as a `long` and contains a Unix Ti
 
 The `duration(string)` function constructs a duration value from a duration string. Strict validation requires the argument to be a literal, although evaluation/authorization support any appropriately-typed expressions. The `string` is a concatenated sequence of quantity-unit pairs. For example, `"1d2h3m4s5ms"` is a valid duration string.
 
-The quantity part is a positive integer. The unit is one of the following:
+The quantity part is a natural number. The unit is one of the following:
 
 - `d`: days
 - `h`: hours
@@ -205,7 +205,7 @@ Equality is based on the underlying representation (see below) so, for example, 
 
 #### Representation
 
-The `duration` type is internally represented as a positive or negative quantity of milliseconds as a `long`.
+The `duration` type is internally represented as a quantity of milliseconds as a `long`, which can be positive, negative, or zero.
 
 A negative duration may be useful when a user wants to use `.offset()` to shift a date backwards.
 For example: `context.now.offset(duration("-3d"))` expresses "three days before the current date".


### PR DESCRIPTION
@emina noted in [this comment](https://github.com/cedar-policy/cedar-spec/pull/471) that the specification for `duration` might be wrong, as the set of positive integers does not include zero. But we should be able to specify zero-amount units and durations.
<!--
The below link will link to the rendered Markdown for your RFC, even before it is merged. You need to adjust it based on your RFC's filename and which fork and branch your PR is from.

* USERNAME: adpaco-aws

* REPONAME: rfcs

* BRANCHNAME: zero-durations

* FILENAME.md: 0080-datetime-extension.md

Examples:

https://github.com/cedar-policy/rfcs/blob/placeholders-in-conditions/text/0003-placeholders-in-conditions.md

https://github.com/myusername/rfcs/blob/awesome-rfc-idea/text/0001-awesome-rfc-idea.md

-->

<!-- FIXME -->
[Rendered](https://github.com/USERNAME/REPONAME/blob/BRANCHNAME/text/FILENAME.md)
