### PR TITLE
Set additional restrictions on datetime string formats

### DIFF
--- a/text/0080-datetime-extension.md
+++ b/text/0080-datetime-extension.md
@@ -142,6 +142,16 @@ The `datetime(string)` function constructs a datetime value. Like with other ext
 - `"YYYY-MM-DDThh:mm:ss(+/-)hhmm"` (With timezone offset in hours and minutes)
 - `"YYYY-MM-DDThh:mm:ss.SSS(+/-)hhmm"` (With timezone offset in hours and minutes and millisecond precision)
 
+All formats must adhere to these additional restrictions:
+- The month field (`MM`) must be in the range 01-12
+- The day field (`DD`) must be in the range 01-31
+- The hour field (`hh`) must be in the range 00-23
+- The minute field (`mm`) must be in the range 00-59
+- The seconds field (`ss`) must be in the range 00-59 (leap seconds are not supported)
+
+Note that the restrictions on the hour and minute fields also apply to timezone offsets.
+This implies that timezone offsets must have an absolute value less than 24 hours (i.e., between `-2359` and `+2359`).
+
 The `datetime` type does not provide a way for a policy author to create a `datetime` from a numeric timestamp. One of the readable formats listed above must be used, instead.
 
 Values of type `datetime` have the following methods:
@@ -469,3 +479,10 @@ The current proposal supports milliseconds. The ISO 8601 format does not specify
 During discussion, we decided that sub-second accuracy was potentially useful, but we did not have a use case in mind for sub-millisecond accuracy.
 So in the end we landed on milliseconds.
 Note that this is the backwards compatible option (at least with respect to allowable date/time strings) because we can add precision later, but not remove it without a breaking change.
+
+### Additional restrictions on datetime strings
+
+The current proposal sets additional restrictions on most fields of datetime string formats.
+These restrictions are common in datetime frameworks for popular programming languages like Python and TypeScript
+(more details [here](https://github.com/cedar-policy/cedar-spec/pull/519#issuecomment-2613547897)),
+and they help us avoid discrepancies between different Cedar implementations.


### PR DESCRIPTION
<!--
The below link will link to the rendered Markdown for your RFC, even before it is merged. You need to adjust it based on your RFC's filename and which fork and branch your PR is from.

* USERNAME: GitHub account or org where your fork of `rfcs` lives. Internal users using a feature branch of `cedar-policy` can just put `cedar-policy` here.

* REPONAME: Probably `rfcs` unless your fork has a different name

* BRANCHNAME: Name of the branch your PR is based on

* FILENAME.md: Filename of your RFC's markdown

Examples:

https://github.com/cedar-policy/rfcs/blob/placeholders-in-conditions/text/0003-placeholders-in-conditions.md

https://github.com/myusername/rfcs/blob/awesome-rfc-idea/text/0001-awesome-rfc-idea.md

-->

Update the RFC for the `datetime` extension to set additional restrictions on datetime string formats.

These restrictions are based on [this comparison table](https://github.com/cedar-policy/cedar-spec/pull/519#issuecomment-2613547897) which made clear some discrepancies between Cedar implementations and the common restrictions in popular datetime frameworks.
<!-- FIXME -->
[Rendered](https://github.com/adpaco-aws/rfcs/blob/datetime-restrictions/text/0080-datetime-extension.md)
