### PR TITLE
Add RFC 99 to summary file

### DIFF
--- a/text/SUMMARY.md
+++ b/text/SUMMARY.md
@@ -22,3 +22,4 @@
 - [0076-entity-slice-validation](0076-entity-slice-validation.md)
 - [0080-datetime-extension](0080-datetime-extension.md)
 - [0082-entity-tags](0082-entity-tags.md)
+- [0099-ip-is-in-range-list](0099-ip-is-in-range-list.md)


### PR DESCRIPTION
RFC #99 doesn't show on the [Cedar RFC Book](https://cedar-policy.github.io/rfcs/). I suppose because it's missing from the `SUMMARY.md` file.